### PR TITLE
fix(hooks): patch azureml artifact builder for MLflow 3.10+ compatibility

### DIFF
--- a/src/kedro_azureml_pipeline/hooks/local_run.py
+++ b/src/kedro_azureml_pipeline/hooks/local_run.py
@@ -1,10 +1,15 @@
 """Kedro hooks for Azure ML dataset integration."""
 
+import inspect
+import logging
+
 from kedro.framework.hooks import hook_impl
 
 from kedro_azureml_pipeline.config import WorkspacesConfig
 from kedro_azureml_pipeline.datasets.asset_dataset import AzureMLAssetDataset
 from kedro_azureml_pipeline.runner import AzurePipelinesRunner
+
+logger = logging.getLogger(__name__)
 
 
 class AzureMLLocalRunHook:
@@ -17,6 +22,39 @@ class AzureMLLocalRunHook:
     [WorkspacesConfig][kedro_azureml_pipeline.config.WorkspacesConfig] : Workspace config injected into datasets.
     """
 
+    @staticmethod
+    def _patch_azureml_artifact_builder() -> None:
+        """Re-register the ``azureml`` artifact builder with a ``**kwargs``-tolerant wrapper.
+
+        MLflow 3.10+ passes ``tracking_uri`` and ``registry_uri`` keyword arguments
+        to artifact repository builders, but ``azureml-mlflow``'s
+        ``azureml_artifacts_builder`` does not accept them, causing a ``TypeError``.
+
+        This method wraps the original builder so that extra keyword arguments are
+        silently dropped.  The patch is a no-op when:
+
+        * ``mlflow`` or ``azureml-mlflow`` is not installed.
+        * The builder already accepts ``**kwargs`` (i.e. azureml-mlflow was updated).
+        """
+        try:
+            from azureml.mlflow.entry_point_loaders import azureml_artifacts_builder
+            from mlflow.store.artifact.artifact_repository_registry import _artifact_repository_registry
+        except ImportError:
+            return
+
+        params = inspect.signature(azureml_artifacts_builder).parameters
+        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+            return
+
+        original = azureml_artifacts_builder
+
+        def _tolerant_builder(artifact_uri=None, **kwargs):  # noqa: ARG001
+            """Wrap the original builder, forwarding only ``artifact_uri``."""
+            return original(artifact_uri=artifact_uri)
+
+        _artifact_repository_registry.register("azureml", _tolerant_builder)
+        logger.info("kedro-azureml-pipeline: patched azureml artifact builder to accept extra kwargs")
+
     @hook_impl
     def after_context_created(self, context) -> None:
         """Register the ``azureml`` config pattern and resolve workspace config.
@@ -26,6 +64,7 @@ class AzureMLLocalRunHook:
         context : KedroContext
             Kedro project context.
         """
+        self._patch_azureml_artifact_builder()
         if "azureml" not in context.config_loader.config_patterns:
             context.config_loader.config_patterns.update({"azureml": ["azureml*", "azureml*/**", "**/azureml*"]})
         self.azure_config = WorkspacesConfig.model_validate(context.config_loader["azureml"]["workspace"]).resolve()

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from kedro.io.core import Version
@@ -107,3 +107,94 @@ class TestAzureMLLocalRunHook:
     def test_module_level_singleton_exists(self):
         """The module exports a ready-to-use hook instance."""
         assert isinstance(azureml_local_run_hook, AzureMLLocalRunHook)
+
+
+class TestPatchAzuremlArtifactBuilder:
+    """Tests for ``AzureMLLocalRunHook._patch_azureml_artifact_builder``."""
+
+    def test_wraps_builder_that_lacks_var_keyword(self):
+        """The wrapper forwards ``artifact_uri`` and drops extra kwargs."""
+        mock_registry = MagicMock()
+        sentinel = object()
+
+        def fake_builder(artifact_uri=None):
+            return sentinel
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "mlflow": MagicMock(),
+                    "mlflow.store": MagicMock(),
+                    "mlflow.store.artifact": MagicMock(),
+                    "mlflow.store.artifact.artifact_repository_registry": MagicMock(
+                        _artifact_repository_registry=mock_registry,
+                    ),
+                    "azureml": MagicMock(),
+                    "azureml.mlflow": MagicMock(),
+                    "azureml.mlflow.entry_point_loaders": MagicMock(
+                        azureml_artifacts_builder=fake_builder,
+                    ),
+                },
+            ),
+        ):
+            AzureMLLocalRunHook._patch_azureml_artifact_builder()
+
+        mock_registry.register.assert_called_once()
+        scheme, wrapper = mock_registry.register.call_args[0]
+        assert scheme == "azureml"
+
+        result = wrapper(artifact_uri="azureml://foo", tracking_uri="http://t", registry_uri="http://r")
+        assert result is sentinel
+
+    def test_noop_when_builder_already_accepts_kwargs(self):
+        """Patch is skipped when the builder already accepts ``**kwargs``."""
+        mock_registry = MagicMock()
+
+        def compatible_builder(artifact_uri=None, **kwargs):
+            pass
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "mlflow": MagicMock(),
+                    "mlflow.store": MagicMock(),
+                    "mlflow.store.artifact": MagicMock(),
+                    "mlflow.store.artifact.artifact_repository_registry": MagicMock(
+                        _artifact_repository_registry=mock_registry,
+                    ),
+                    "azureml": MagicMock(),
+                    "azureml.mlflow": MagicMock(),
+                    "azureml.mlflow.entry_point_loaders": MagicMock(
+                        azureml_artifacts_builder=compatible_builder,
+                    ),
+                },
+            ),
+        ):
+            AzureMLLocalRunHook._patch_azureml_artifact_builder()
+
+        mock_registry.register.assert_not_called()
+
+    def test_noop_when_mlflow_not_installed(self):
+        """Patch is a silent no-op when mlflow is not importable."""
+        with patch.dict("sys.modules", {"mlflow": None}):
+            AzureMLLocalRunHook._patch_azureml_artifact_builder()
+
+    def test_noop_when_azureml_mlflow_not_installed(self):
+        """Patch is a silent no-op when azureml-mlflow is not importable."""
+        with patch.dict("sys.modules", {"azureml": None, "azureml.mlflow": None}):
+            AzureMLLocalRunHook._patch_azureml_artifact_builder()
+
+    def test_called_during_after_context_created(self, mock_azureml_config):
+        """``after_context_created`` invokes the patch."""
+        hook = AzureMLLocalRunHook()
+        context_mock = Mock(
+            config_loader=MagicMock(
+                __getitem__=Mock(return_value={"workspace": {"__default__": mock_azureml_config.to_dict()}}),
+                config_patterns={},
+            )
+        )
+        with patch.object(AzureMLLocalRunHook, "_patch_azureml_artifact_builder") as mock_patch:
+            hook.after_context_created(context_mock)
+            mock_patch.assert_called_once()


### PR DESCRIPTION
## Description

Patch `azureml-mlflow`'s artifact builder to accept extra keyword arguments (`tracking_uri`, `registry_uri`) passed by MLflow 3.10+, preventing a `TypeError` when saving artifacts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

MLflow 3.10+ passes `tracking_uri` and `registry_uri` kwargs to all artifact repository builders, but `azureml-mlflow` 1.60.0's `azureml_artifacts_builder(artifact_uri=None)` only accepts `artifact_uri`. This causes a `TypeError` when `MlflowArtifactDataset` saves an artifact.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings