### PR TITLE
docs: fix license link to point to repository LICENSE file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ Kedro AzureML Pipeline is a [Kedro](https://docs.kedro.org/) plugin that connect
 
 ## License
 
-Kedro AzureML Pipeline is open source and licensed under the [Apache-2.0 License](https://opensource.org/licenses/Apache-2.0).
+This project is licensed under the terms of the [Apache-2.0 License](https://github.com/stateful-y/kedro-azureml-pipeline/blob/main/LICENSE).
 
 ## Acknowledgements
 
@@ -62,6 +62,6 @@ We would also like to thank [Evolta Technologies](https://www.evolta-technologie
 
 ![Evolta Technologies](assets/evolta_logo.png){width=400}
 
-This project is maintained by [stateful-y](https://stateful-y.io), an ML consultancy specializing in MLOps and data science & engineering.
+This project is maintained by [stateful-y](https://stateful-y.io), an ML consultancy specializing in MLOps and data science & engineering. If you're interested in collaborating or learning more about our services, please visit our website.
 
 ![Made by stateful-y](assets/made_by_stateful-y.png){width=200}


### PR DESCRIPTION
## Description

Update the license link in `docs/index.md` to point to the repository's LICENSE file instead of a generic URL.

## Type of Change

- [x] Documentation update

## Motivation and Context

The license link pointed to the generic opensource.org URL instead of the actual LICENSE file in the repository.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed
- [x] My changes generate no new warnings