### PR TITLE
feat: add `kedro azureml schedule --delete` CLI command

### DIFF
--- a/src/kedro_azureml_pipeline/cli/commands.py
+++ b/src/kedro_azureml_pipeline/cli/commands.py
@@ -361,7 +361,6 @@ def schedule(
         else:
             click.echo(click.style("Some schedule deletions failed", fg="red"))
             click_context.exit(1)
-        return
 
     params = json.dumps(p) if (p := parse_runtime_params(params)) else ""
 

--- a/src/kedro_azureml_pipeline/cli/commands.py
+++ b/src/kedro_azureml_pipeline/cli/commands.py
@@ -13,6 +13,7 @@ from kedro.framework.startup import ProjectMetadata
 
 from kedro_azureml_pipeline.cli.functions import (
     compile_job_pipelines,
+    delete_schedules,
     dynamic_import_job_schedule_func_from_str,
     parse_extra_env_params,
     parse_runtime_params,
@@ -312,6 +313,12 @@ def run(
     default=False,
     help="Preview what would be scheduled without actually calling Azure ML.",
 )
+@click.option(
+    "--delete",
+    is_flag=True,
+    default=False,
+    help="Delete the specified schedules instead of creating/updating them.",
+)
 @click.pass_obj
 @click.pass_context
 def schedule(
@@ -324,12 +331,38 @@ def schedule(
     env_var: tuple[str],
     load_versions: dict[str, str],
     dry_run: bool,
+    delete: bool,
 ):
     """Create or update persistent Azure ML schedules for named jobs.
 
     Jobs are defined in the 'jobs' section of azureml.yml. Each job must
     have a schedule configured; an error is raised otherwise.
+
+    Use ``--delete`` to remove schedules instead of creating them.
+    ``--delete`` is mutually exclusive with ``--aml-env``.
     """
+    if delete and aml_env:
+        raise click.UsageError("--delete and --aml-env are mutually exclusive.")
+
+    if delete:
+        warn_about_ignore_files()
+        verify_configuration_directory_for_azure(click_context, ctx)
+
+        is_ok = delete_schedules(
+            ctx=ctx,
+            job_names=list(job_names),
+            dry_run=dry_run,
+            workspace_override=workspace_name,
+        )
+
+        if is_ok:
+            click.echo(click.style("All schedules deleted successfully", fg="green"))
+            click_context.exit(0)
+        else:
+            click.echo(click.style("Some schedule deletions failed", fg="red"))
+            click_context.exit(1)
+        return
+
     params = json.dumps(p) if (p := parse_runtime_params(params)) else ""
 
     if workspace_name:

--- a/src/kedro_azureml_pipeline/cli/functions.py
+++ b/src/kedro_azureml_pipeline/cli/functions.py
@@ -492,6 +492,78 @@ def run_jobs(
         return all(results.values())
 
 
+def delete_schedules(
+    ctx: CliContext,
+    job_names: list[str],
+    dry_run: bool,
+    workspace_override: str | None = None,
+) -> bool:
+    """Delete Azure ML schedules for the specified jobs.
+
+    Schedule names match job names (the convention used by
+    ``build_job_schedule``).  No pipeline compilation is performed.
+
+    Parameters
+    ----------
+    ctx : CliContext
+        CLI context containing the Kedro environment and metadata.
+    job_names : list of str
+        Job names whose schedules should be deleted.
+    dry_run : bool
+        Preview mode: print what would happen without calling Azure ML.
+    workspace_override : str or None
+        Named workspace override for all jobs in this batch.
+
+    Returns
+    -------
+    bool
+        ``True`` if all deletions succeeded (or were no-ops).
+    """
+    from kedro_azureml_pipeline.scheduler import AzureMLScheduleClient
+
+    with KedroContextManager(env=ctx.env) as mgr:
+        config = mgr.plugin_config
+
+        if not config.jobs:
+            raise click.ClickException(
+                "No 'jobs' section found in azureml.yml config. Define jobs to use this command."
+            )
+
+        missing = set(job_names) - set(config.jobs.keys())
+        if missing:
+            raise click.ClickException(
+                f"Job(s) not found in config: {', '.join(sorted(missing))}. "
+                f"Available jobs: {', '.join(sorted(config.jobs.keys()))}"
+            )
+
+        schedule_client = AzureMLScheduleClient()
+        results: dict[str, bool] = {}
+
+        for job_name in job_names:
+            try:
+                job_config = config.jobs[job_name]
+                workspace = config.workspace.resolve(workspace_override or job_config.workspace)
+
+                if dry_run:
+                    click.echo(f"[DRY RUN] Would delete schedule '{job_name}'")
+                    results[job_name] = True
+                else:
+                    schedule_client.delete_schedule(job_name, workspace)
+                    click.echo(click.style(f"Schedule '{job_name}' deleted", fg="green"))
+                    results[job_name] = True
+
+            except Exception as e:
+                click.echo(click.style(f"Failed to delete schedule '{job_name}': {e}", fg="red"))
+                logger.exception(f"Error deleting schedule '{job_name}'")
+                results[job_name] = False
+
+        succeeded = sum(1 for v in results.values() if v)
+        failed = sum(1 for v in results.values() if not v)
+        click.echo(f"\nDelete summary: {succeeded} succeeded, {failed} failed (out of {len(results)} schedules)")
+
+        return all(results.values())
+
+
 def schedule_jobs(
     ctx: CliContext,
     aml_env: str | None,

--- a/src/kedro_azureml_pipeline/scheduler.py
+++ b/src/kedro_azureml_pipeline/scheduler.py
@@ -186,3 +186,31 @@ class AzureMLScheduleClient:
             ).result()
             logger.info(f"Schedule '{result.name}' created/updated successfully")
             return result
+
+    def delete_schedule(
+        self,
+        name: str,
+        config: WorkspaceConfig,
+    ) -> None:
+        """Disable and delete a schedule from the Azure ML workspace.
+
+        Azure ML requires a schedule to be disabled before it can be
+        deleted.  If the schedule does not exist, a warning is logged
+        and the call is treated as a no-op.
+
+        Parameters
+        ----------
+        name : str
+            Schedule name to delete.
+        config : WorkspaceConfig
+            Workspace configuration for the ``MLClient``.
+        """
+        from azure.core.exceptions import ResourceNotFoundError
+
+        with _get_azureml_client(config) as ml_client:
+            try:
+                ml_client.schedules.begin_disable(name=name).result()
+                ml_client.schedules.begin_delete(name=name).result()
+                logger.info(f"Schedule '{name}' deleted successfully")
+            except ResourceNotFoundError:
+                logger.warning(f"Schedule '{name}' not found, skipping delete")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -292,8 +292,6 @@ class TestScheduler:
     def test_delete_schedule_not_found_is_noop(self):
         from azure.core.exceptions import ResourceNotFoundError
 
-        from kedro_azureml_pipeline.client import _get_azureml_client
-
         mock_ml_client = MagicMock()
         mock_ml_client.schedules.begin_disable.side_effect = ResourceNotFoundError("not found")
 
@@ -872,6 +870,78 @@ class TestScheduleDeleteCLI:
             assert result.exit_code != 0
             assert "mutually exclusive" in result.output.lower()
 
+    def test_delete_no_jobs_config_errors(
+        self,
+        dummy_plugin_config,
+        patched_kedro_package,
+        cli_context,
+        tmp_path,
+    ):
+        """--delete should error when no jobs section exists in config."""
+        from click.testing import CliRunner
+
+        import kedro_azureml_pipeline.cli.commands as cli
+        from kedro_azureml_pipeline.manager import KedroContextManager
+
+        create_kedro_conf_dirs(tmp_path)
+
+        assert dummy_plugin_config.jobs == {}
+
+        mock_mgr = MagicMock(spec=KedroContextManager)
+        mock_mgr.plugin_config = dummy_plugin_config
+
+        with (
+            patch.object(KedroContextManager, "__enter__", return_value=mock_mgr),
+            patch.object(KedroContextManager, "__exit__", return_value=False),
+            patch.object(Path, "cwd", return_value=tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.schedule,
+                ["--delete", "-j", "any_job"],
+                obj=cli_context,
+            )
+            assert result.exit_code != 0
+            assert "No 'jobs' section" in result.output
+
+    def test_delete_missing_job_name_errors(
+        self,
+        dummy_plugin_config,
+        patched_kedro_package,
+        cli_context,
+        tmp_path,
+    ):
+        """--delete with a non-existent job name should error."""
+        from click.testing import CliRunner
+
+        import kedro_azureml_pipeline.cli.commands as cli
+        from kedro_azureml_pipeline.manager import KedroContextManager
+
+        create_kedro_conf_dirs(tmp_path)
+
+        dummy_plugin_config.jobs = {
+            "real_job": JobConfig(
+                pipeline=PipelineFilterOptions(pipeline_name="__default__"),
+            ),
+        }
+
+        mock_mgr = MagicMock(spec=KedroContextManager)
+        mock_mgr.plugin_config = dummy_plugin_config
+
+        with (
+            patch.object(KedroContextManager, "__enter__", return_value=mock_mgr),
+            patch.object(KedroContextManager, "__exit__", return_value=False),
+            patch.object(Path, "cwd", return_value=tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.schedule,
+                ["--delete", "-j", "nonexistent"],
+                obj=cli_context,
+            )
+            assert result.exit_code != 0
+            assert "not found" in result.output
+
 
 class TestRunCLI:
     """``kedro azureml run`` CLI integration."""
@@ -1077,3 +1147,18 @@ class TestAzureMLScheduleClient:
             result = schedule_client.create_or_update_schedule(mock_schedule, mock_workspace)
             assert result.name == "test-schedule"
             mock_ml_client.schedules.begin_create_or_update.assert_called_once_with(schedule=mock_schedule)
+
+    def test_delete_schedule_success(self):
+        from kedro_azureml_pipeline.scheduler import AzureMLScheduleClient
+
+        mock_ml_client = MagicMock()
+
+        with patch("kedro_azureml_pipeline.scheduler._get_azureml_client") as mock_ctx:
+            mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_ml_client)
+            mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            client = AzureMLScheduleClient()
+            client.delete_schedule("my_schedule", MagicMock())
+
+        mock_ml_client.schedules.begin_disable.assert_called_once_with(name="my_schedule")
+        mock_ml_client.schedules.begin_delete.assert_called_once_with(name="my_schedule")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -22,6 +22,7 @@ from kedro_azureml_pipeline.config import (
 )
 from kedro_azureml_pipeline.generator import AzureMLPipelineGenerator
 from kedro_azureml_pipeline.scheduler import (
+    AzureMLScheduleClient,
     build_job_schedule,
     build_trigger,
     resolve_schedule,
@@ -287,6 +288,26 @@ class TestScheduler:
         )
         assert isinstance(schedule, JobSchedule)
         assert schedule.name == "test_schedule"
+
+    def test_delete_schedule_not_found_is_noop(self):
+        from azure.core.exceptions import ResourceNotFoundError
+
+        from kedro_azureml_pipeline.client import _get_azureml_client
+
+        mock_ml_client = MagicMock()
+        mock_ml_client.schedules.begin_disable.side_effect = ResourceNotFoundError("not found")
+
+        with patch(
+            "kedro_azureml_pipeline.scheduler._get_azureml_client",
+        ) as mock_get_client:
+            mock_get_client.return_value.__enter__ = MagicMock(return_value=mock_ml_client)
+            mock_get_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            client = AzureMLScheduleClient()
+            # Should not raise
+            client.delete_schedule("nonexistent", MagicMock())
+
+        mock_ml_client.schedules.begin_delete.assert_not_called()
 
 
 class TestScheduleCLI:
@@ -701,6 +722,155 @@ class TestScheduleCLI:
             )
             assert result.exit_code != 0
             assert "no schedule configured" in result.output
+
+
+class TestScheduleDeleteCLI:
+    """``kedro azureml schedule --delete`` CLI integration."""
+
+    def test_delete_dry_run(
+        self,
+        dummy_plugin_config,
+        patched_kedro_package,
+        cli_context,
+        tmp_path,
+    ):
+        """--delete --dry-run should preview without calling Azure."""
+        from click.testing import CliRunner
+
+        import kedro_azureml_pipeline.cli.commands as cli
+        from kedro_azureml_pipeline.manager import KedroContextManager
+
+        create_kedro_conf_dirs(tmp_path)
+        dummy_plugin_config.jobs = {
+            "test_job": JobConfig(
+                pipeline=PipelineFilterOptions(pipeline_name="__default__"),
+            ),
+        }
+
+        mock_mgr = MagicMock(spec=KedroContextManager)
+        mock_mgr.plugin_config = dummy_plugin_config
+
+        with (
+            patch.object(KedroContextManager, "__enter__", return_value=mock_mgr),
+            patch.object(KedroContextManager, "__exit__", return_value=False),
+            patch.object(Path, "cwd", return_value=tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.schedule,
+                ["--delete", "--dry-run", "-j", "test_job"],
+                obj=cli_context,
+            )
+            assert result.exit_code == 0, result.output
+            assert "[DRY RUN]" in result.output
+            assert "test_job" in result.output
+
+    def test_delete_succeeds(
+        self,
+        dummy_plugin_config,
+        patched_kedro_package,
+        cli_context,
+        tmp_path,
+    ):
+        """--delete should call delete_schedule and report success."""
+        from click.testing import CliRunner
+
+        import kedro_azureml_pipeline.cli.commands as cli
+        from kedro_azureml_pipeline.manager import KedroContextManager
+        from kedro_azureml_pipeline.scheduler import AzureMLScheduleClient
+
+        create_kedro_conf_dirs(tmp_path)
+        dummy_plugin_config.jobs = {
+            "test_job": JobConfig(
+                pipeline=PipelineFilterOptions(pipeline_name="__default__"),
+            ),
+        }
+
+        mock_mgr = MagicMock(spec=KedroContextManager)
+        mock_mgr.plugin_config = dummy_plugin_config
+
+        with (
+            patch.object(KedroContextManager, "__enter__", return_value=mock_mgr),
+            patch.object(KedroContextManager, "__exit__", return_value=False),
+            patch.object(Path, "cwd", return_value=tmp_path),
+            patch.object(AzureMLScheduleClient, "delete_schedule") as mock_delete,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.schedule,
+                ["--delete", "-j", "test_job"],
+                obj=cli_context,
+            )
+            assert result.exit_code == 0, result.output
+            assert "deleted" in result.output
+            mock_delete.assert_called_once()
+
+    def test_delete_failure_exit_code(
+        self,
+        dummy_plugin_config,
+        patched_kedro_package,
+        cli_context,
+        tmp_path,
+    ):
+        """When deletion fails, exit code is non-zero."""
+        from click.testing import CliRunner
+
+        import kedro_azureml_pipeline.cli.commands as cli
+        from kedro_azureml_pipeline.manager import KedroContextManager
+        from kedro_azureml_pipeline.scheduler import AzureMLScheduleClient
+
+        create_kedro_conf_dirs(tmp_path)
+        dummy_plugin_config.jobs = {
+            "test_job": JobConfig(
+                pipeline=PipelineFilterOptions(pipeline_name="__default__"),
+            ),
+        }
+
+        mock_mgr = MagicMock(spec=KedroContextManager)
+        mock_mgr.plugin_config = dummy_plugin_config
+
+        with (
+            patch.object(KedroContextManager, "__enter__", return_value=mock_mgr),
+            patch.object(KedroContextManager, "__exit__", return_value=False),
+            patch.object(Path, "cwd", return_value=tmp_path),
+            patch.object(
+                AzureMLScheduleClient,
+                "delete_schedule",
+                side_effect=RuntimeError("Azure error"),
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.schedule,
+                ["--delete", "-j", "test_job"],
+                obj=cli_context,
+            )
+            assert result.exit_code == 1
+            assert "failed" in result.output.lower()
+
+    def test_delete_mutually_exclusive_with_aml_env(
+        self,
+        dummy_plugin_config,
+        patched_kedro_package,
+        cli_context,
+        tmp_path,
+    ):
+        """--delete and --aml-env cannot be used together."""
+        from click.testing import CliRunner
+
+        import kedro_azureml_pipeline.cli.commands as cli
+
+        create_kedro_conf_dirs(tmp_path)
+
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.schedule,
+                ["--delete", "--aml-env", "foo@latest", "-j", "test_job"],
+                obj=cli_context,
+            )
+            assert result.exit_code != 0
+            assert "mutually exclusive" in result.output.lower()
 
 
 class TestRunCLI:


### PR DESCRIPTION
## Description

Add a `--delete` flag to the `kedro azureml schedule` CLI command that disables and deletes named Azure ML schedules.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Supports challenger model deactivation workflows by allowing schedule deletion directly from the CLI without manual Azure ML portal interaction.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- `--delete` is mutually exclusive with `--aml-env`
- Supports `--dry-run` for safe previewing
- `ResourceNotFoundError` is handled gracefully (logged as warning, not failure)
