### PR TITLE
fix: relax kedro-mlflow pin to >=1.0.0 in mlflow extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 mlflow = [
     "azureml-mlflow>=1.42.0",
     "mlflow>=2.0.0",
-    "kedro-mlflow>=2.0.0",
+    "kedro-mlflow>=1.0.0",
 ]
 
 [project.entry-points."kedro.project_commands"]


### PR DESCRIPTION
## Description

Relax the `kedro-mlflow` pin in the `[mlflow]` optional dependency from `>=2.0.0` to `>=1.0.0`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

`kedro-mlflow>=2.0.0` requires `mlflow>=3.0`, which introduces a mandatory Logged Models API (`/api/2.0/mlflow/logged-models`). Azure ML's tracking server does not support this endpoint, causing `log_model()` to fail with a 404 error. Relaxing the pin allows using `kedro-mlflow==1.0.2` with `mlflow<3`, which avoids the unsupported endpoint while remaining compatible with `kedro>=1.0,<2.0`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings