### PR TITLE
fix: gracefully handle missing azureml workspace config and resolve dataset factories in data_path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ omit = [
 precision = 2
 show_missing = true
 skip_covered = false
-fail_under = 1
+fail_under = 100
 include_namespace_packages = true
 
 [tool.coverage.html]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,22 +242,19 @@ exclude = ["CHANGELOG.md", "site", "htmlcov", ".nox", ".venv"]
 "CONTRIBUTING.md" = ["MD057"]  # Relative link to docs/ is valid at project level
 
 [tool.ty]
-# Pre-existing type issues in Azure ML SDK integration & Click parameter coercion.
-# TODO: Gradually fix and re-enable these rules.
+# Third-party SDK type stubs (Azure ML, Kedro) have incomplete or incorrect annotations.
 [tool.ty.rules]
-invalid-assignment = "warn"
-invalid-argument-type = "warn"
+call-non-callable = "warn"
+invalid-method-override = "warn"
 invalid-parameter-default = "warn"
 invalid-return-type = "warn"
+invalid-type-form = "warn"
+missing-argument = "warn"
+no-matching-overload = "warn"
+not-subscriptable = "warn"
 unresolved-attribute = "warn"
 unresolved-import = "warn"
-no-matching-overload = "warn"
-invalid-method-override = "warn"
-not-subscriptable = "warn"
-call-non-callable = "warn"
 unsupported-operator = "warn"
-missing-argument = "warn"
-invalid-type-form = "warn"
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 mlflow = [
     "azureml-mlflow>=1.42.0",
     "mlflow>=2.0.0",
-    "kedro-mlflow>=1.0.0",
+    "kedro-mlflow>=2.0.0",
 ]
 
 [project.entry-points."kedro.project_commands"]

--- a/src/kedro_azureml_pipeline/cli/commands.py
+++ b/src/kedro_azureml_pipeline/cli/commands.py
@@ -436,9 +436,9 @@ def execute(
     """Execute a single pipeline node inside Azure ML (internal)."""
     # 1. Run kedro
     parameters = parse_runtime_params(params)
-    azure_inputs = dict(azure_inputs)
-    azure_outputs = dict(azure_outputs)
-    data_paths = {**azure_inputs, **azure_outputs}
+    inputs_map = dict(azure_inputs)
+    outputs_map = dict(azure_outputs)
+    data_paths = {**inputs_map, **outputs_map}
 
     with KedroContextManager(env=ctx.env, runtime_params=parameters) as mgr:
         runner = AzurePipelinesRunner(data_paths=data_paths)

--- a/src/kedro_azureml_pipeline/cli/functions.py
+++ b/src/kedro_azureml_pipeline/cli/functions.py
@@ -644,11 +644,12 @@ def schedule_jobs(
                 )
 
                 if dry_run:
-                    trigger_desc = (
-                        f"cron: {schedule_cfg.cron.expression}"
-                        if schedule_cfg.cron
-                        else f"recurrence: every {schedule_cfg.recurrence.interval} {schedule_cfg.recurrence.frequency}(s)"
-                    )
+                    if schedule_cfg.cron:
+                        trigger_desc = f"cron: {schedule_cfg.cron.expression}"
+                    else:
+                        rec = schedule_cfg.recurrence
+                        assert rec is not None
+                        trigger_desc = f"recurrence: every {rec.interval} {rec.frequency}(s)"
                     click.echo(
                         f"[DRY RUN] Would create schedule '{job_name}' "
                         f"({trigger_desc}) "

--- a/src/kedro_azureml_pipeline/datasets/asset_dataset.py
+++ b/src/kedro_azureml_pipeline/datasets/asset_dataset.py
@@ -182,6 +182,7 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
         return self._dataset_type(**dataset_config)
 
     def _require_config(self) -> WorkspaceConfig:
+        """Return the Azure ML config or raise if not set."""
         if self._azureml_config is None:
             raise DatasetError(f"Azure ML workspace config is not set on dataset '{self}'")
         return self._azureml_config

--- a/src/kedro_azureml_pipeline/datasets/asset_dataset.py
+++ b/src/kedro_azureml_pipeline/datasets/asset_dataset.py
@@ -72,7 +72,7 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
         azureml_type: AzureMLDataAssetType = "uri_folder",
         version: Version | None = None,
         azureml_version: str | None = None,
-        metadata: dict[str, Any] = None,
+        metadata: dict[str, Any] | None = None,
     ):
         super().__init__(
             dataset=dataset,
@@ -92,7 +92,7 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
         # resolution includes the dataset name and version prefix.
         self._download = True
         self._local_run = True
-        self._azureml_config = None
+        self._azureml_config: WorkspaceConfig | None = None
         self._azureml_type = azureml_type
         if self._azureml_type not in get_args(AzureMLDataAssetType):
             raise DatasetError(
@@ -110,7 +110,7 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
             )
 
     @property
-    def azure_config(self) -> WorkspaceConfig:
+    def azure_config(self) -> WorkspaceConfig | None:
         """Return the Azure ML workspace configuration.
 
         Returns
@@ -132,7 +132,7 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
         self._azureml_config = azure_config
 
     @property
-    def path(self) -> str:
+    def path(self) -> Path:
         """Return the full path to the underlying dataset file.
 
         Returns
@@ -181,6 +181,11 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
         dataset_config[self._filepath_arg] = str(self.path)
         return self._dataset_type(**dataset_config)
 
+    def _require_config(self) -> WorkspaceConfig:
+        if self._azureml_config is None:
+            raise DatasetError(f"Azure ML workspace config is not set on dataset '{self}'")
+        return self._azureml_config
+
     def _get_latest_version(self) -> str:
         """Fetch the latest Data Asset version from Azure ML.
 
@@ -195,7 +200,7 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
             If the Data Asset does not exist.
         """
         try:
-            with _get_azureml_client(config=self._azureml_config) as ml_client:
+            with _get_azureml_client(config=self._require_config()) as ml_client:
                 return ml_client.data.get(self._azureml_dataset, label="latest").version
         except ResourceNotFoundError as exc:
             raise DatasetNotFoundError(f"Did not find Azure ML Data Asset for {self}") from exc
@@ -234,7 +239,7 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
         Data
             Azure ML Data Asset.
         """
-        with _get_azureml_client(config=self._azureml_config) as ml_client:
+        with _get_azureml_client(config=self._require_config()) as ml_client:
             return ml_client.data.get(self._azureml_dataset, version=self._resolve_azureml_version())
 
     def _load(self) -> Any:
@@ -260,7 +265,7 @@ class AzureMLAssetDataset(AzureMLPipelineDataset, AbstractVersionedDataset):
 
             # Use Azure ML SDK native download functionality
             # This avoids the ARM64 compatibility issues with azureml-fsspec
-            with _get_azureml_client(config=self._azureml_config) as ml_client:
+            with _get_azureml_client(config=self._require_config()) as ml_client:
                 logger.info(
                     f"Downloading dataset {self._azureml_dataset} version "
                     f"{self._resolve_azureml_version()} for local execution"

--- a/src/kedro_azureml_pipeline/datasets/pipeline_dataset.py
+++ b/src/kedro_azureml_pipeline/datasets/pipeline_dataset.py
@@ -51,7 +51,7 @@ class AzureMLPipelineDataset(AbstractDataset):
         dataset: str | type[AbstractDataset] | dict[str, Any],
         root_dir: str = "data",
         filepath_arg: str = "filepath",
-        metadata: dict[str, Any] = None,
+        metadata: dict[str, Any] | None = None,
     ):
         dataset = dataset if isinstance(dataset, dict) else {"type": dataset}
         self._dataset_type, self._dataset_config = parse_dataset_definition(dataset)
@@ -73,7 +73,7 @@ class AzureMLPipelineDataset(AbstractDataset):
             )
 
     @property
-    def path(self) -> str:
+    def path(self) -> Path:
         """Return the full path to the underlying dataset file.
 
         Returns
@@ -84,7 +84,7 @@ class AzureMLPipelineDataset(AbstractDataset):
         return Path(self.root_dir) / Path(self._dataset_config[self._filepath_arg])
 
     @property
-    def _filepath(self) -> str:
+    def _filepath(self) -> Path:
         """Return path for kedro-mlflow compatibility.
 
         Returns

--- a/src/kedro_azureml_pipeline/generator.py
+++ b/src/kedro_azureml_pipeline/generator.py
@@ -101,8 +101,8 @@ class AzureMLPipelineGenerator:
         catalog: DataCatalog,
         aml_env: str | None = None,
         params: str | None = None,
-        extra_env: dict[str, str] = None,
-        load_versions: dict[str, str] = None,
+        extra_env: dict[str, str] | None = None,
+        load_versions: dict[str, str] | None = None,
         filter_options: PipelineFilterOptions | None = None,
         mlflow_run_name: str | None = None,
         experiment_name: str | None = None,
@@ -258,7 +258,7 @@ class AzureMLPipelineGenerator:
         else:
             return (params or self.kedro_params)[param_name]
 
-    def _resolve_azure_environment(self) -> str:
+    def _resolve_azure_environment(self) -> str | None:
         """Return the Azure ML environment name.
 
         Returns

--- a/src/kedro_azureml_pipeline/hooks/local_run.py
+++ b/src/kedro_azureml_pipeline/hooks/local_run.py
@@ -3,6 +3,7 @@
 import inspect
 import logging
 
+from kedro.config import MissingConfigException
 from kedro.framework.hooks import hook_impl
 
 from kedro_azureml_pipeline.config import WorkspacesConfig
@@ -67,7 +68,11 @@ class AzureMLLocalRunHook:
         self._patch_azureml_artifact_builder()
         if "azureml" not in context.config_loader.config_patterns:
             context.config_loader.config_patterns.update({"azureml": ["azureml*", "azureml*/**", "**/azureml*"]})
-        self.azure_config = WorkspacesConfig.model_validate(context.config_loader["azureml"]["workspace"]).resolve()
+        try:
+            self.azure_config = WorkspacesConfig.model_validate(context.config_loader["azureml"]["workspace"]).resolve()
+        except (KeyError, MissingConfigException):
+            self.azure_config = None
+            logger.info("kedro-azureml-pipeline: no azureml config found, skipping workspace resolution")
 
     @hook_impl
     def after_catalog_created(self, catalog):
@@ -78,6 +83,8 @@ class AzureMLLocalRunHook:
         catalog : DataCatalog
             Created data catalog.
         """
+        if self.azure_config is None:
+            return
         for dataset_name in catalog.filter():
             dataset = catalog[dataset_name]
             if isinstance(dataset, AzureMLAssetDataset):

--- a/src/kedro_azureml_pipeline/manager.py
+++ b/src/kedro_azureml_pipeline/manager.py
@@ -142,4 +142,5 @@ class KedroContextManager:
         exc_tb : TracebackType or None
             Traceback.
         """
-        self.session.__exit__(exc_type, exc_val, exc_tb)
+        if self.session is not None:
+            self.session.__exit__(exc_type, exc_val, exc_tb)

--- a/src/kedro_azureml_pipeline/runner.py
+++ b/src/kedro_azureml_pipeline/runner.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from kedro.io import AbstractDataset, DataCatalog
+from kedro.io import AbstractDataset, CatalogProtocol, DataCatalog
 from kedro.pipeline import Pipeline
 from kedro.runner import SequentialRunner
 from kedro_datasets.pickle import PickleDataset
@@ -44,10 +44,10 @@ class AzurePipelinesRunner(SequentialRunner):
     def run(
         self,
         pipeline: Pipeline,
-        catalog: DataCatalog,
-        hook_manager: PluginManager = None,
+        catalog: CatalogProtocol,
+        hook_manager: PluginManager | None = None,
+        run_id: str | None = None,
         only_missing_outputs: bool = False,
-        run_id: str = None,
     ) -> dict[str, Any]:
         """Execute the pipeline with Azure ML dataset path rewiring.
 
@@ -59,16 +59,17 @@ class AzurePipelinesRunner(SequentialRunner):
             Data catalog.
         hook_manager : PluginManager or None
             Pluggy hook manager.
-        only_missing_outputs : bool
-            If ``True``, only run nodes whose outputs are missing.
         run_id : str or None
             Unique run identifier.
+        only_missing_outputs : bool
+            If ``True``, only run nodes whose outputs are missing.
 
         Returns
         -------
         dict of str to Any
             Mapping of output dataset names to their values.
         """
+        assert isinstance(catalog, DataCatalog), f"AzurePipelinesRunner requires a DataCatalog, got {type(catalog)}"
         # Preserve Azure configs from existing datasets before copying
         azure_configs = {}
         for ds_name in catalog.filter():

--- a/src/kedro_azureml_pipeline/runner.py
+++ b/src/kedro_azureml_pipeline/runner.py
@@ -106,6 +106,11 @@ class AzurePipelinesRunner(SequentialRunner):
                         ds.root_dir = azure_dataset_path
                     logger.debug("Rewired dataset '%s' root_dir to '%s'", ds_name, ds.root_dir)
                     updated_catalog[ds_name] = ds
+            elif ds_name in catalog:
+                # Resolve factory patterns (e.g. "product.{group}.{variant}.output")
+                ds = catalog[ds_name]
+                updated_catalog[ds_name] = ds
+                logger.debug("Resolved factory dataset '%s'", ds_name)
             else:
                 updated_catalog[ds_name] = self.create_default_data_set(ds_name)
                 logger.debug("Created default pickle dataset for '%s'", ds_name)

--- a/src/kedro_azureml_pipeline/scheduler.py
+++ b/src/kedro_azureml_pipeline/scheduler.py
@@ -1,6 +1,7 @@
 """Azure ML schedule creation and management."""
 
 import logging
+from typing import Any
 
 from azure.ai.ml.entities import (
     CronTrigger,
@@ -85,26 +86,27 @@ def build_trigger(config: ScheduleConfig) -> CronTrigger | RecurrenceTrigger:
         return CronTrigger(**kwargs)
 
     rec = config.recurrence
-    kwargs = {
-        "frequency": rec.frequency,
-        "interval": rec.interval,
-        "time_zone": rec.time_zone,
-    }
-    if rec.start_time:
-        kwargs["start_time"] = rec.start_time
-    if rec.end_time:
-        kwargs["end_time"] = rec.end_time
+    assert rec is not None, "ScheduleConfig must have either cron or recurrence set"
+
+    pattern: RecurrencePattern | None = None
     if rec.schedule:
-        pattern_kwargs = {}
+        pattern_kwargs: dict[str, Any] = {}
         if rec.schedule.hours is not None:  # pragma: no branch - RecurrencePattern requires hours
             pattern_kwargs["hours"] = rec.schedule.hours
         if rec.schedule.minutes is not None:  # pragma: no branch - RecurrencePattern requires minutes
             pattern_kwargs["minutes"] = rec.schedule.minutes
         if rec.schedule.week_days is not None:
             pattern_kwargs["week_days"] = rec.schedule.week_days
-        kwargs["schedule"] = RecurrencePattern(**pattern_kwargs)
+        pattern = RecurrencePattern(**pattern_kwargs)
 
-    return RecurrenceTrigger(**kwargs)
+    return RecurrenceTrigger(
+        frequency=rec.frequency,
+        interval=rec.interval,
+        time_zone=rec.time_zone,
+        start_time=rec.start_time,
+        end_time=rec.end_time,
+        schedule=pattern,
+    )
 
 
 def build_job_schedule(
@@ -139,16 +141,13 @@ def build_job_schedule(
     [build_trigger][kedro_azureml_pipeline.scheduler.build_trigger] : Creates the trigger argument.
     [AzureMLScheduleClient][kedro_azureml_pipeline.scheduler.AzureMLScheduleClient] : Submits this schedule.
     """
-    kwargs = {
-        "name": name,
-        "trigger": trigger,
-        "create_job": pipeline_job,
-    }
-    if display_name:
-        kwargs["display_name"] = display_name
-    if description:
-        kwargs["description"] = description
-    return JobSchedule(**kwargs)
+    return JobSchedule(
+        name=name,
+        trigger=trigger,
+        create_job=pipeline_job,
+        display_name=display_name or None,
+        description=description or None,
+    )
 
 
 class AzureMLScheduleClient:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -459,6 +459,16 @@ class TestAzureMLAssetDataset:
         ):
             ds._load()
 
+    def test_require_config_raises_when_none(self):
+        """``_require_config`` raises ``DatasetError`` when Azure ML config is not set."""
+        ds = AzureMLAssetDataset(
+            dataset={"type": PickleDataset, "filepath": "test.pickle"},
+            azureml_dataset="test_ds",
+            version=Version(None, None),
+        )
+        with pytest.raises(DatasetError, match="Azure ML workspace config is not set"):
+            ds._require_config()
+
 
 class TestAzureMLPipelineDataset:
     """Tests for ``AzureMLPipelineDataset`` save and load."""

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -423,6 +423,7 @@ class TestAzureMLAssetDataset:
             azureml_dataset="missing_asset",
             version=Version(None, None),
         )
+        ds._azureml_config = MagicMock()
         mock_client = MagicMock()
         mock_client.data.get.side_effect = ResourceNotFoundError("not found")
         mock_ctx = MagicMock()
@@ -444,6 +445,7 @@ class TestAzureMLAssetDataset:
             azureml_dataset="test_ds",
             azureml_version="99",
         )
+        ds._azureml_config = MagicMock()
         ds._download = True
         mock_client = MagicMock()
         mock_client.data.get.side_effect = ResourceNotFoundError("version 99 not found")

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -132,6 +132,10 @@ class TestAzureMLLocalRunHook:
 class TestPatchAzuremlArtifactBuilder:
     """Tests for ``AzureMLLocalRunHook._patch_azureml_artifact_builder``."""
 
+    def test_patches_real_azureml_builder(self):
+        """Patch runs against the real ``azureml-mlflow`` package without errors."""
+        AzureMLLocalRunHook._patch_azureml_artifact_builder()
+
     def test_wraps_builder_that_lacks_var_keyword(self):
         """The wrapper forwards ``artifact_uri`` and drops extra kwargs."""
         mock_registry = MagicMock()
@@ -198,12 +202,27 @@ class TestPatchAzuremlArtifactBuilder:
 
     def test_noop_when_mlflow_not_installed(self):
         """Patch is a silent no-op when mlflow is not importable."""
-        with patch.dict("sys.modules", {"mlflow": None}):
+        with patch.dict(
+            "sys.modules",
+            {
+                "mlflow": None,
+                "mlflow.store": None,
+                "mlflow.store.artifact": None,
+                "mlflow.store.artifact.artifact_repository_registry": None,
+            },
+        ):
             AzureMLLocalRunHook._patch_azureml_artifact_builder()
 
     def test_noop_when_azureml_mlflow_not_installed(self):
         """Patch is a silent no-op when azureml-mlflow is not importable."""
-        with patch.dict("sys.modules", {"azureml": None, "azureml.mlflow": None}):
+        with patch.dict(
+            "sys.modules",
+            {
+                "azureml": None,
+                "azureml.mlflow": None,
+                "azureml.mlflow.entry_point_loaders": None,
+            },
+        ):
             AzureMLLocalRunHook._patch_azureml_artifact_builder()
 
     def test_called_during_after_context_created(self, mock_azureml_config):

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from kedro.config import MissingConfigException
 from kedro.io.core import Version
 from kedro.runner import SequentialRunner
 
@@ -103,6 +104,25 @@ class TestAzureMLLocalRunHook:
         hook.azure_config = mock_azureml_config
         hook.after_catalog_created(catalog)
         assert catalog["mem"].load() == 42
+
+    @pytest.mark.parametrize("exc", [KeyError("azureml"), MissingConfigException("no config")])
+    def test_missing_config_sets_none_and_skips_catalog(self, exc, multi_catalog):
+        """When azureml config is missing, ``azure_config`` is ``None`` and catalog is skipped."""
+        hook = AzureMLLocalRunHook()
+        context_mock = Mock(
+            config_loader=MagicMock(
+                __getitem__=Mock(side_effect=exc),
+                config_patterns={},
+            )
+        )
+        hook.after_context_created(context_mock)
+        assert hook.azure_config is None
+
+        hook.after_catalog_created(multi_catalog)
+        for dataset_name in multi_catalog.filter():
+            dataset = multi_catalog[dataset_name]
+            if isinstance(dataset, AzureMLAssetDataset):
+                assert dataset._azureml_config is None
 
     def test_module_level_singleton_exists(self):
         """The module exports a ready-to-use hook instance."""

--- a/tests/test_kedro_context_manager.py
+++ b/tests/test_kedro_context_manager.py
@@ -80,3 +80,9 @@ class TestKedroContextManager:
         plain = {"a": 1}
         result = mgr._ensure_obj_is_dict(plain)
         assert result == {"a": 1}
+
+    def test_exit_noop_when_session_is_none(self):
+        """``__exit__`` is a no-op when session was never created."""
+        mgr = KedroContextManager(env="base")
+        assert mgr.session is None
+        mgr.__exit__(None, None, None)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -70,6 +70,28 @@ class TestAzurePipelinesRunner:
         ds = runner.create_default_data_set("my_ds")
         assert isinstance(ds, AzureMLPipelineDataset)
 
+    def test_data_paths_resolves_factory_datasets(self, dummy_pipeline: Pipeline, tmp_path: Path):
+        """Datasets in data_paths that are resolvable via catalog factory patterns
+        should be resolved from the catalog, not replaced with a default pickle dataset."""
+        input_data = ["factory data"]
+        factory_dataset = MemoryDataset(data=input_data)
+
+        catalog = DataCatalog()
+        catalog["input_data"] = MemoryDataset(data=input_data)
+        # Simulate a dataset that the generator wired as an AzureML stream
+        # but is resolvable from the original catalog (e.g. via a factory pattern).
+        # i2 is an intermediate dataset not explicitly in catalog but resolvable.
+        catalog["i2"] = factory_dataset
+
+        runner = AzurePipelinesRunner(
+            data_paths={"i2": str(tmp_path), "i3": str(tmp_path), "output_data": str(tmp_path)}
+        )
+        results = runner.run(dummy_pipeline, catalog)
+
+        # i2 should have been resolved from the catalog (MemoryDataset),
+        # not replaced with a pickle dataset.
+        assert results["output_data"].load() == input_data
+
 
 class TestDatasetPathAdjustments:
     """Tests for root_dir rewiring in the runner."""

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -536,6 +536,61 @@ class TestScheduleCLI:
             assert "[DRY RUN]" in result.output
             assert "test_job" in result.output
 
+    def test_schedule_dry_run_recurrence(
+        self,
+        tagged_pipeline,
+        dummy_plugin_config,
+        multi_catalog,
+        patched_kedro_package,
+        cli_context,
+        tmp_path,
+    ):
+        """--dry-run with a recurrence schedule reports interval and frequency."""
+        from click.testing import CliRunner
+
+        import kedro_azureml_pipeline.cli.commands as cli
+        from kedro_azureml_pipeline.manager import KedroContextManager
+
+        create_kedro_conf_dirs(tmp_path)
+
+        dummy_plugin_config.schedules = {
+            "weekly": ScheduleConfig(
+                recurrence=RecurrenceScheduleConfig(frequency="week", interval=2),
+            ),
+        }
+        dummy_plugin_config.jobs = {
+            "test_job": JobConfig(
+                pipeline=PipelineFilterOptions(pipeline_name="__default__"),
+                schedule="weekly",
+            ),
+        }
+
+        mock_mgr = MagicMock(spec=KedroContextManager)
+        mock_mgr.plugin_config = dummy_plugin_config
+        mock_mgr.context.params = {}
+        mock_mgr.context.catalog = multi_catalog
+        mock_mgr.context.config_loader.__getitem__ = MagicMock(side_effect=KeyError("mlflow"))
+
+        with (
+            patch.object(KedroContextManager, "__enter__", return_value=mock_mgr),
+            patch.object(KedroContextManager, "__exit__", return_value=False),
+            patch.object(
+                AzureMLPipelineGenerator,
+                "get_kedro_pipeline",
+                return_value=tagged_pipeline,
+            ),
+            patch.object(Path, "cwd", return_value=tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.schedule,
+                ["-j", "test_job", "--dry-run"],
+                obj=cli_context,
+            )
+            assert result.exit_code == 0, result.output
+            assert "[DRY RUN]" in result.output
+            assert "recurrence: every 2 week(s)" in result.output
+
     def test_schedule_job_filter(
         self,
         tagged_pipeline,


### PR DESCRIPTION
## Description

Gracefully handle missing azureml workspace configuration in `AzureMLLocalRunHook` so projects without an `azureml.yml` can still load the hook without errors. Also bumps `kedro-mlflow` optional dependency to `>=2.0.0`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

When a project installs `kedro-azureml-pipeline` but does not provide an `azureml.yml` config file, the `after_context_created` hook raises a `KeyError` or `MissingConfigException`. This change catches those exceptions, sets `azure_config` to `None`, and skips catalog injection accordingly.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

