### PR TITLE
fix(mlflow): resolve experiment ID from run metadata before start_run

### DIFF
--- a/src/kedro_azureml_pipeline/hooks/mlflow.py
+++ b/src/kedro_azureml_pipeline/hooks/mlflow.py
@@ -65,13 +65,6 @@ class MlflowAzureMLHook:
 
         experiment_name = os.environ.get(KEDRO_AZUREML_MLFLOW_EXPERIMENT_NAME)
         if experiment_name:
-            # When MLFLOW_RUN_ID is set, AzureML already assigned the run to
-            # its own experiment.  Setting MLFLOW_EXPERIMENT_NAME would cause
-            # kedro-mlflow to call set_experiment() with a name that resolves
-            # to a different experiment ID, triggering an ID mismatch error.
-            if os.environ.get("MLFLOW_RUN_ID"):
-                logger.info("kedro-azureml-pipeline: MLFLOW_RUN_ID is set, skipping MLFLOW_EXPERIMENT_NAME override")
-                return
             os.environ["MLFLOW_EXPERIMENT_NAME"] = experiment_name
             logger.info("kedro-azureml-pipeline: set MLFLOW_EXPERIMENT_NAME=%s", experiment_name)
 
@@ -107,12 +100,18 @@ class MlflowAzureMLHook:
             run_id = os.environ.get("MLFLOW_RUN_ID")
             if run_id:
                 # The run already exists in AzureML under its own experiment.
-                # Starting it directly avoids an experiment ID mismatch that
-                # occurs when set_experiment() resolves to a different ID.
+                # kedro-mlflow may have called set_experiment() with a name
+                # from mlflow.yml, setting _active_experiment_id to the wrong
+                # value.  We must align it with the run's actual experiment
+                # before calling start_run() to avoid an ID mismatch.
+                client = mlflow.MlflowClient()
+                run_info = client.get_run(run_id)
+                mlflow.set_experiment(experiment_id=run_info.info.experiment_id)
                 mlflow.start_run(run_id=run_id)
                 logger.info(
-                    "kedro-azureml-pipeline: resumed MLflow run %s (experiment set by AzureML)",
+                    "kedro-azureml-pipeline: resumed MLflow run %s (experiment_id=%s)",
                     run_id,
+                    run_info.info.experiment_id,
                 )
             else:
                 mlflow.set_experiment(experiment_name)

--- a/tests/test_mlflow_hook.py
+++ b/tests/test_mlflow_hook.py
@@ -64,16 +64,16 @@ class TestAfterContextCreated:
 
         assert "MLFLOW_EXPERIMENT_NAME" not in os.environ
 
-    def test_skips_env_var_when_mlflow_run_id_set(self, hook):
-        """When MLFLOW_RUN_ID is set by AzureML, skip setting
-        MLFLOW_EXPERIMENT_NAME to avoid experiment ID mismatch."""
+    def test_sets_env_var_even_when_mlflow_run_id_set(self, hook):
+        """MLFLOW_EXPERIMENT_NAME is set unconditionally; before_pipeline_run
+        will correct the active experiment from the run metadata."""
         os.environ[KEDRO_AZUREML_MLFLOW_ENABLED] = "1"
         os.environ[KEDRO_AZUREML_MLFLOW_EXPERIMENT_NAME] = "job-experiment"
         os.environ["MLFLOW_RUN_ID"] = "aml-run-123"
 
         hook.after_context_created(context=MagicMock())
 
-        assert "MLFLOW_EXPERIMENT_NAME" not in os.environ
+        assert os.environ["MLFLOW_EXPERIMENT_NAME"] == "job-experiment"
 
 
 class TestBeforePipelineRun:
@@ -101,9 +101,9 @@ class TestBeforePipelineRun:
             mock_mlflow.set_tags.assert_not_called()
 
     def test_starts_run_with_correct_experiment(self, hook):
-        """When MLFLOW_RUN_ID is set by AzureML, the hook should start the
-        run directly without calling set_experiment (to avoid experiment ID
-        mismatch with AzureML-managed experiments)."""
+        """When MLFLOW_RUN_ID is set by AzureML, the hook should fetch the
+        run's experiment ID via get_run() and call set_experiment(experiment_id=...)
+        before start_run() to align with the run's actual experiment."""
         os.environ[KEDRO_AZUREML_MLFLOW_ENABLED] = "1"
         os.environ[KEDRO_AZUREML_MLFLOW_EXPERIMENT_NAME] = "job-experiment"
         os.environ["MLFLOW_RUN_ID"] = "aml-run-123"
@@ -115,6 +115,11 @@ class TestBeforePipelineRun:
         mock_active_run.info.run_id = "aml-run-123"
         mock_mlflow.active_run.side_effect = [None, mock_active_run]
 
+        # MlflowClient().get_run() returns run info with experiment_id
+        mock_run_info = MagicMock()
+        mock_run_info.info.experiment_id = "exp-actual-456"
+        mock_mlflow.MlflowClient().get_run.return_value = mock_run_info
+
         with patch.dict("sys.modules", {"mlflow": mock_mlflow}):
             hook.before_pipeline_run(
                 run_params={},
@@ -122,8 +127,38 @@ class TestBeforePipelineRun:
                 catalog=MagicMock(),
             )
 
-        mock_mlflow.set_experiment.assert_not_called()
+        mock_mlflow.MlflowClient().get_run.assert_called_once_with("aml-run-123")
+        mock_mlflow.set_experiment.assert_called_once_with(experiment_id="exp-actual-456")
         mock_mlflow.start_run.assert_called_once_with(run_id="aml-run-123")
+
+    def test_uses_experiment_id_from_run_not_env(self, hook):
+        """The experiment ID passed to set_experiment must come from the fetched
+        run metadata, not from the MLFLOW_EXPERIMENT_NAME env var."""
+        os.environ[KEDRO_AZUREML_MLFLOW_ENABLED] = "1"
+        os.environ[KEDRO_AZUREML_MLFLOW_EXPERIMENT_NAME] = "wrong-experiment"
+        os.environ["MLFLOW_RUN_ID"] = "aml-run-789"
+
+        mock_mlflow = MagicMock()
+        mock_active_run = MagicMock()
+        mock_active_run.info.run_id = "aml-run-789"
+        mock_mlflow.active_run.side_effect = [None, mock_active_run]
+
+        mock_run_info = MagicMock()
+        mock_run_info.info.experiment_id = "exp-correct-id"
+        mock_mlflow.MlflowClient().get_run.return_value = mock_run_info
+
+        with patch.dict("sys.modules", {"mlflow": mock_mlflow}):
+            hook.before_pipeline_run(
+                run_params={},
+                pipeline=MagicMock(),
+                catalog=MagicMock(),
+            )
+
+        # Must use the experiment_id from run metadata, not experiment_name from env
+        mock_mlflow.set_experiment.assert_called_once_with(experiment_id="exp-correct-id")
+        # Must NOT have been called with the env var experiment name
+        for call in mock_mlflow.set_experiment.call_args_list:
+            assert call != (("wrong-experiment",),)
 
     def test_skips_start_run_when_no_mlflow_run_id(self, hook):
         """Without MLFLOW_RUN_ID, the hook sets the experiment but does not


### PR DESCRIPTION
## Description

Before calling `start_run(run_id=...)` with an AzureML-provided run ID, fetch the run's actual `experiment_id` via `MlflowClient().get_run()` and call `set_experiment(experiment_id=...)` to align the active experiment. This fixes the experiment ID mismatch caused by kedro-mlflow's own `after_context_created` hook calling `set_experiment()` with the name from `mlflow.yml`, which resolves to a different experiment than the one AzureML assigned to the run.

Also removes the `MLFLOW_RUN_ID` guard in `after_context_created` since `before_pipeline_run` now corrects the experiment regardless.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

When kedro pipelines run inside Azure ML, kedro-mlflow's `after_context_created` hook reads `mlflow.yml` and calls `mlflow.set_experiment("evolta-forecast-staging")`, setting `_active_experiment_id` to that experiment's ID. When our hook later calls `mlflow.start_run(run_id=...)` with the AzureML-provided run ID, MLflow checks the active experiment ID against the run's actual experiment ID (set by AzureML) and rejects the mismatch with `MlflowException`.

The previous fix (PR #22) skipped `set_experiment()` entirely but was insufficient because kedro-mlflow independently calls `set_experiment()` from its own hook.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (19/19)
- [x] My changes generate no new warnings