### PR TITLE
fix: set experiment_name on scheduled pipeline jobs

### DIFF
--- a/src/kedro_azureml_pipeline/cli/functions.py
+++ b/src/kedro_azureml_pipeline/cli/functions.py
@@ -632,6 +632,12 @@ def schedule_jobs(
                 workspace = config.workspace.resolve(workspace_override or job_config.workspace)
                 pipeline_opts = job_config.pipeline
 
+                # Set experiment_name on the pipeline job so AzureML uses it
+                # for scheduled runs (analogous to run_jobs passing it to
+                # ml_client.jobs.create_or_update).
+                if job_experiment_name:
+                    pipeline_job.experiment_name = job_experiment_name
+
                 schedule_cfg = resolve_schedule(job_config.schedule, config.schedules)
                 trigger = build_trigger(schedule_cfg)
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -482,6 +482,72 @@ class TestScheduleCLI:
             assert "created/updated successfully" in result.output
             assert "All schedules created successfully" in result.output
 
+    def test_schedule_sets_experiment_name_on_pipeline_job(
+        self,
+        tagged_pipeline,
+        dummy_plugin_config,
+        multi_catalog,
+        patched_kedro_package,
+        cli_context,
+        tmp_path,
+    ):
+        """Scheduled jobs should carry the experiment_name from the job config."""
+        from click.testing import CliRunner
+
+        import kedro_azureml_pipeline.cli.commands as cli
+        from kedro_azureml_pipeline.manager import KedroContextManager
+
+        create_kedro_conf_dirs(tmp_path)
+        dummy_plugin_config.schedules = {
+            "daily": ScheduleConfig(cron=CronScheduleConfig(expression="0 6 * * *")),
+        }
+        dummy_plugin_config.jobs = {
+            "test_job": JobConfig(
+                pipeline=PipelineFilterOptions(pipeline_name="__default__"),
+                schedule="daily",
+                experiment_name="prod-inference",
+            ),
+        }
+
+        mock_mgr = MagicMock(spec=KedroContextManager)
+        mock_mgr.plugin_config = dummy_plugin_config
+        mock_mgr.context.params = {}
+        mock_mgr.context.catalog = multi_catalog
+        mock_mgr.context.config_loader.__getitem__ = MagicMock(side_effect=KeyError("mlflow"))
+
+        mock_result = MagicMock()
+        mock_result.name = "test_job"
+
+        captured_schedule = {}
+
+        def capture_schedule(schedule, config):
+            captured_schedule["pipeline_job"] = schedule.create_job
+            return mock_result
+
+        with (
+            patch.object(KedroContextManager, "__enter__", return_value=mock_mgr),
+            patch.object(KedroContextManager, "__exit__", return_value=False),
+            patch.object(
+                AzureMLPipelineGenerator,
+                "get_kedro_pipeline",
+                return_value=tagged_pipeline,
+            ),
+            patch.object(Path, "cwd", return_value=tmp_path),
+            patch.object(
+                AzureMLScheduleClient,
+                "create_or_update_schedule",
+                side_effect=capture_schedule,
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.schedule,
+                ["-j", "test_job"],
+                obj=cli_context,
+            )
+            assert result.exit_code == 0, result.output
+            assert captured_schedule["pipeline_job"].experiment_name == "prod-inference"
+
     def test_schedule_dry_run(
         self,
         tagged_pipeline,


### PR DESCRIPTION
## Description

Set `experiment_name` on the pipeline job in `schedule_jobs()` so scheduled runs use the correct experiment.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Scheduled pipeline jobs were not inheriting the `experiment_name` from config. This fix propagates it to the pipeline job before creating the schedule, matching the behavior of `run_jobs()`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings