### PR TITLE
feat: add job-level params field to JobConfig with CLI merge

### DIFF
--- a/src/kedro_azureml_pipeline/cli/functions.py
+++ b/src/kedro_azureml_pipeline/cli/functions.py
@@ -66,6 +66,27 @@ def parse_runtime_params(params, silent=False):
     return parameters
 
 
+def _merge_job_params(cli_params: str, job_config) -> str:
+    """Merge job-level params with CLI params (CLI wins).
+
+    Parameters
+    ----------
+    cli_params : str
+        Raw CLI ``--params`` JSON string.
+    job_config : JobConfig
+        Job configuration potentially containing ``params``.
+
+    Returns
+    -------
+    str
+        Merged params as a JSON string, or empty string when none.
+    """
+    job_params = job_config.params or {}
+    cli_parsed = parse_runtime_params(cli_params, silent=True) or {}
+    merged = {**job_params, **cli_parsed}
+    return json.dumps(merged) if merged else ""
+
+
 def warn_about_ignore_files():
     """Emit warnings about ``.amlignore`` and ``.gitignore`` files.
 
@@ -297,7 +318,7 @@ def compile_job_pipelines(
                 mgr.context.params,
                 mgr.context.catalog,
                 aml_env,
-                params,
+                _merge_job_params(params, job_config),
                 extra_env=extra_env,
                 load_versions=load_versions,
                 filter_options=pipeline_opts,
@@ -380,7 +401,7 @@ def _prepare_jobs(
                 mgr.context.params,
                 mgr.context.catalog,
                 aml_env,
-                params,
+                _merge_job_params(params, job_config),
                 extra_env=extra_env,
                 load_versions=load_versions,
                 filter_options=pipeline_opts,

--- a/src/kedro_azureml_pipeline/config/models.py
+++ b/src/kedro_azureml_pipeline/config/models.py
@@ -399,6 +399,8 @@ class JobConfig(BaseModel):
         Named compute entry to use.
     schedule : ScheduleConfig or str or None
         Inline schedule, named schedule reference, or ``None`` for ad-hoc.
+    params : dict of str to Any or None
+        Job-level runtime parameters merged into every step. CLI --params take precedence.
     retry : RetryConfig or None
         Retry settings applied to every step in this job.
     description : str or None
@@ -440,12 +442,12 @@ class JobConfig(BaseModel):
     schedule: ScheduleConfig | str | None = Field(
         default=None, description="Inline schedule, named schedule reference, or None for ad-hoc."
     )
-    retry: RetryConfig | None = Field(default=None, description="Retry settings applied to every step in this job.")
-    description: str | None = Field(default=None, description="Human-readable job description.")
     params: dict[str, Any] | None = Field(
         default=None,
         description="Job-level runtime parameters merged into every step. CLI --params take precedence.",
     )
+    retry: RetryConfig | None = Field(default=None, description="Retry settings applied to every step in this job.")
+    description: str | None = Field(default=None, description="Human-readable job description.")
 
 
 class KedroAzureMLConfig(BaseModel):

--- a/src/kedro_azureml_pipeline/config/models.py
+++ b/src/kedro_azureml_pipeline/config/models.py
@@ -442,6 +442,10 @@ class JobConfig(BaseModel):
     )
     retry: RetryConfig | None = Field(default=None, description="Retry settings applied to every step in this job.")
     description: str | None = Field(default=None, description="Human-readable job description.")
+    params: dict[str, Any] | None = Field(
+        default=None,
+        description="Job-level runtime parameters merged into every step. CLI --params take precedence.",
+    )
 
 
 class KedroAzureMLConfig(BaseModel):

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -7,6 +7,7 @@ import click
 import pytest
 
 from kedro_azureml_pipeline.cli.functions import (
+    _merge_job_params,
     _read_mlflow_experiment_name,
     default_job_callback,
     dynamic_import_job_schedule_func_from_str,
@@ -195,3 +196,41 @@ class TestReadMlflowExperimentName:
         mgr = MagicMock()
         mgr.context.config_loader.__getitem__ = MagicMock(side_effect=TypeError)
         assert _read_mlflow_experiment_name(mgr) is None
+
+
+class TestMergeJobParams:
+    """Job-level params merging with CLI params."""
+
+    def test_job_params_only(self):
+        job = MagicMock()
+        job.params = {"arena_snapshot": "2026-06"}
+        result = _merge_job_params("", job)
+        assert result == '{"arena_snapshot": "2026-06"}'
+
+    def test_cli_params_only(self):
+        job = MagicMock()
+        job.params = None
+        result = _merge_job_params('{"lr": 0.01}', job)
+        assert result == '{"lr": 0.01}'
+
+    def test_cli_overrides_job(self):
+        job = MagicMock()
+        job.params = {"arena_snapshot": "2026-06", "lr": 0.1}
+        result = _merge_job_params('{"lr": 0.01}', job)
+        import json
+
+        merged = json.loads(result)
+        assert merged["arena_snapshot"] == "2026-06"
+        assert merged["lr"] == 0.01
+
+    def test_both_empty(self):
+        job = MagicMock()
+        job.params = None
+        result = _merge_job_params("", job)
+        assert result == ""
+
+    def test_job_params_empty_dict(self):
+        job = MagicMock()
+        job.params = {}
+        result = _merge_job_params("", job)
+        assert result == ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -236,6 +236,17 @@ class TestJobConfig:
         assert jc.retry.max_retries == 3
         assert jc.retry.timeout == 3600
 
+    def test_params_default_none(self):
+        jc = JobConfig(pipeline=PipelineFilterOptions(pipeline_name="pipe"))
+        assert jc.params is None
+
+    def test_params_set(self):
+        jc = JobConfig(
+            pipeline=PipelineFilterOptions(pipeline_name="pipe"),
+            params={"arena_snapshot": "2026-06", "model.lr": 0.01},
+        )
+        assert jc.params == {"arena_snapshot": "2026-06", "model.lr": 0.01}
+
 
 class TestKedroAzureMLConfig:
     """Top-level config parsing and template."""


### PR DESCRIPTION
## Description

Add an optional `params: dict[str, Any] | None` field to `JobConfig` so that jobs can declare runtime parameters directly in `azureml.yml`. Job-level params are merged with CLI `--params` at compile/run time, with CLI values taking precedence.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

The forecasting arena needs per-job parameters (e.g. `arena_snapshot`) baked into job definitions so operators don't have to remember to pass them via CLI every time. Previously, `--params` was the only way to inject runtime parameters and applied uniformly to all jobs.

Example usage in `azureml.yml`:

```yaml
jobs:
  arena-da-energy-hub:
    pipeline:
      pipeline_name: backtesting
      node_namespaces: ["da_energy.hub"]
    experiment_name: "arena-da_energy-hub"
    params:
      arena_snapshot: "2026-06"
```

CLI overrides still win: `--params='{"arena_snapshot": "2026-07"}'` overrides the YAML value.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings