### PR TITLE
feat: make uv.lock the single source of truth for lint tooling

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 226fe0719fa3b860d876d5fd06906e8d93c8d875
+_commit: 5b742a4dcc1c7b4b61a1ff7d1139e2fb7ca8f62d
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
 
   # Maintain Python dependencies (pyproject.toml + uv.lock).
   # The "uv" ecosystem (not "pip") is required so Dependabot reads uv.lock and the
-  # PEP 735 [dependency-groups] (dev/lint/tests/docs) where tools like ty/ruff live.
+  # PEP 735 [dependency-groups] (dev/lint/tests/docs) where tools like ty/ruff/rumdl live.
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
@@ -20,7 +20,16 @@ updates:
       - "dependencies"
       - "python"
     groups:
-      # Batch all Python updates into one weekly PR to keep noise low; CI still gates it.
+      # Batch the version-sensitive linters into one lockstep PR so local == CI
+      # stays true after upgrades. uv.lock is their single source of truth.
+      lint-tools:
+        patterns:
+          - "ruff"
+          - "rumdl"
+          - "ty"
+          - "interrogate"
+          - "pre-commit*"
+      # Batch everything else (runtime, tests, docs) into a second PR to keep noise low.
       python-dependencies:
         patterns:
           - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ examples/__marimo__/
 # Ruff
 .ruff_cache/
 
+# OpenSpec (local working artifacts, not tracked)
+openspec/
+
 # build
 src/kedro_azureml_pipeline/_version.py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,40 +23,63 @@ repos:
         stages: [commit-msg]
 
 
-  - repo: https://github.com/econchick/interrogate
-    rev: 1.7.0
+  # Version-sensitive linters run from the project environment so their single
+  # source of truth is uv.lock. --locked makes a stale uv.lock fail loudly
+  # instead of silently diverging from CI. (Dependabot's "uv" ecosystem then
+  # keeps them updated in lockstep; nothing floats on a frozen pre-commit rev.)
+  - repo: local
     hooks:
-    -   id: interrogate
+      # Docstring coverage
+      - id: interrogate
+        name: interrogate
+        entry: uv run --locked interrogate
+        language: system
         types: [python]
         files: ^src/
         exclude: .*_version\.py$
+        require_serial: true
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
-    hooks:
-      # Run the linter
+      # Ruff linter (autofix)
       - id: ruff
-        args: [--fix]
-      # Run the formatter
+        name: ruff
+        entry: uv run --locked ruff check --force-exclude --fix
+        language: system
+        types_or: [python, pyi, jupyter]
+        require_serial: true
+
+      # Ruff formatter
       - id: ruff-format
+        name: ruff-format
+        entry: uv run --locked ruff format --force-exclude
+        language: system
+        types_or: [python, pyi, jupyter]
+        require_serial: true
 
-  # Markdown linting and formatting with rumdl
-  - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.57
-    hooks:
+      # Markdown linter
       - id: rumdl
-      - id: rumdl-fmt
+        name: rumdl check
+        entry: uv run --locked rumdl check .
+        language: system
+        types: [markdown]
+        pass_filenames: false
+        require_serial: true
 
-  # Type checking with ty
-  - repo: local
-    hooks:
+      # Markdown formatter (fixes fixable violations, fails on the rest)
+      - id: rumdl-fmt
+        name: rumdl format
+        entry: uv run --locked rumdl check --fix .
+        language: system
+        types: [markdown]
+        pass_filenames: false
+        require_serial: true
+
+      # Type checking with ty. --extra mlflow so ty resolves the optional mlflow
+      # code paths (hooks/mlflow.py, hooks/local_run.py) instead of warning.
       - id: ty
         name: ty
-        # --extra mlflow: type-check the optional mlflow code paths (hooks/mlflow.py,
-        #   hooks/local_run.py) instead of emitting unresolved-import warnings.
-        # --locked: use the exact pinned versions from uv.lock so local matches CI.
-        entry: uv run --extra mlflow --locked ty check src
+        entry: uv run --extra mlflow --locked ty check --exit-zero-on-warning src
         language: system
         types: [python]
         files: ^src/
         pass_filenames: false
+        require_serial: true

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -699,7 +699,8 @@ def _process_api_page_content(html, page, config):
     if examples_h2:
         old = examples_h2.group(0)
         new = (
-            old.replace('<h2 id="examples">', '<h3 id="tutorials">')
+            old
+            .replace('<h2 id="examples">', '<h3 id="tutorials">')
             .replace("</h2>", "</h3>")
             .replace(">Examples<", ">Tutorials<")
             .replace("#examples", "#tutorials")

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ default:
 # Install dependencies and pre-commit
 install:
     uv sync --group dev
-    uvx pre-commit install
+    uv run pre-commit install
 
 # Run tests and doctests with parallel execution
 test:
@@ -33,15 +33,15 @@ test-docstrings:
 test-compat +PINS='':
     uvx nox -s test_compat -- {{PINS}}
 
-# Run linters and type checkers
+# Run linters and type checkers (read-only; same lock-pinned tools as 'just fix')
 lint:
-    uv run ruff check src tests
-    uvx rumdl check .
-    uv run ty check src
+    uv run --locked ruff check src tests
+    uv run --locked rumdl check .
+    uv run --extra mlflow --locked ty check --exit-zero-on-warning src
 
 # Format and fix code (via pre-commit)
 fix:
-    uvx pre-commit run --all-files --show-diff-on-failure
+    uv run pre-commit run --all-files --show-diff-on-failure
 
 # Build documentation
 build:

--- a/noxfile.py
+++ b/noxfile.py
@@ -283,8 +283,6 @@ def fix(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "dev",
-        # Pin to uv.lock so CI cannot silently drift to newer dev-tool releases than local.
-        "--locked",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
     # Run pre-commit

--- a/noxfile.py
+++ b/noxfile.py
@@ -247,37 +247,39 @@ def test_docstrings(session: nox.Session) -> None:
 @nox.session(venv_backend="uv")
 def lint(session: nox.Session) -> None:
     """Run linters and type checkers."""
-    # Install dependencies
+    # Install dependencies. --locked pins the exact uv.lock versions so this matches CI.
     session.run_install(
         "uv",
         "sync",
+        "--locked",
         "--no-default-groups",
-        "--group",
-        "lint",
         # Install the project + mlflow extra so ty can resolve azure-ai-ml / mlflow imports.
         "--extra",
         "mlflow",
-        "--locked",
+        "--group",
+        "lint",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 
     # Run ruff check
     session.run("ruff", "check", "src", "tests", external=True)
 
-    # Run rumdl markdown linter
-    session.run("uvx", "rumdl", "check", ".", external=True)
+    # Run rumdl markdown linter (resolved from the lint group, not uvx-latest)
+    session.run("rumdl", "check", ".", external=True)
 
-    # Run ty
-    session.run("ty", "check", "src", external=True)
+    # Run ty (warnings are non-fatal; demoted rules in [tool.ty.rules] stay visible)
+    session.run("ty", "check", "--exit-zero-on-warning", "src", external=True)
 
 
 @nox.session(venv_backend="uv")
 def fix(session: nox.Session) -> None:
     """Format the code base to adhere to our styles, and complain about what we cannot do automatically."""
-    # Install dependencies
+    # Install dependencies. --locked pins the exact uv.lock versions so a stale lock
+    # fails loudly here and local matches CI.
     session.run_install(
         "uv",
         "sync",
+        "--locked",
         "--no-default-groups",
         "--group",
         "dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ tests = [
     "pandas>=2.2.0",
 ]
 lint = [
+    "interrogate>=1.7.0",
     "ruff>=0.8.0",
+    "rumdl>=0.1.33",
     "ty>=0.0.12",
 ]
 docs = [
@@ -122,10 +124,10 @@ select = [
     "T201", # Print statement
 ]
 ignore = [
-    "E203",    # space before : (needed for how black formats slicing)
-    "E501",    # line too long (handled by formatter)
-    "B008",    # do not perform function calls in argument defaults
-    "PLC0415", # import outside top-level (lazy imports used intentionally)
+    "E203",   # space before : (needed for how black formats slicing)
+    "E501",   # line too long (handled by formatter)
+    "B008",   # do not perform function calls in argument defaults
+    "PLC0415", # import not at top-level (lazy imports are intentional, e.g. docs hooks)
     "SIM102",  # collapsible if (clarity over brevity)
     "SIM105",  # contextlib.suppress (comments on except clauses preferred)
     "PLR0913", # too many args in func def
@@ -232,7 +234,7 @@ disable = [
     "MD046",  # Code block style (indented blocks required inside MkDocs tabs)
     "MD051",  # Link fragments (cross-doc references resolved at MkDocs build time)
 ]
-exclude = ["CHANGELOG.md", "site", "htmlcov", ".nox", ".venv"]
+exclude = ["CHANGELOG.md", "site", "htmlcov", ".nox", ".venv", "openspec"]
 
 [tool.rumdl.per-file-ignores]
 ".github/PULL_REQUEST_TEMPLATE.md" = ["MD041"]  # PR template starts with checklist

--- a/uv.lock
+++ b/uv.lock
@@ -1242,6 +1242,22 @@ wheels = [
 ]
 
 [[package]]
+name = "interrogate"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "click" },
+    { name = "colorama" },
+    { name = "py" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/22/74f7fcc96280eea46cf2bcbfa1354ac31de0e60a4be6f7966f12cef20893/interrogate-1.7.0.tar.gz", hash = "sha256:a320d6ec644dfd887cc58247a345054fc4d9f981100c45184470068f4b3719b0", size = 159636, upload-time = "2024-04-07T22:30:46.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/c9/6869a1dcf4aaf309b9543ec070be3ec3adebee7c9bec9af8c230494134b9/interrogate-1.7.0-py3-none-any.whl", hash = "sha256:b13ff4dd8403369670e2efe684066de9fcb868ad9d7f2b4095d8112142dc9d12", size = 46982, upload-time = "2024-04-07T22:30:44.277Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1368,6 +1384,7 @@ mlflow = [
 dev = [
     { name = "covdefaults" },
     { name = "hypothesis" },
+    { name = "interrogate" },
     { name = "mkdocs" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocs-material" },
@@ -1381,6 +1398,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "rumdl" },
     { name = "ty" },
 ]
 docs = [
@@ -1394,7 +1412,9 @@ fix = [
     { name = "pre-commit-uv" },
 ]
 lint = [
+    { name = "interrogate" },
     { name = "ruff" },
+    { name = "rumdl" },
     { name = "ty" },
 ]
 tests = [
@@ -1427,6 +1447,7 @@ provides-extras = ["mlflow"]
 dev = [
     { name = "covdefaults", specifier = ">=2.3" },
     { name = "hypothesis", specifier = ">=6.100" },
+    { name = "interrogate", specifier = ">=1.7.0" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-autorefs", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.7" },
@@ -1440,6 +1461,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.14" },
     { name = "pytest-xdist", specifier = ">=3.8" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "rumdl", specifier = ">=0.1.33" },
     { name = "ty", specifier = ">=0.0.12" },
 ]
 docs = [
@@ -1451,7 +1473,9 @@ docs = [
 ]
 fix = [{ name = "pre-commit-uv", specifier = ">=4.1" }]
 lint = [
+    { name = "interrogate", specifier = ">=1.7.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "rumdl", specifier = ">=0.1.33" },
     { name = "ty", specifier = ">=0.0.12" },
 ]
 tests = [
@@ -2721,6 +2745,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3363,6 +3396,21 @@ wheels = [
 ]
 
 [[package]]
+name = "rumdl"
+version = "0.2.34"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/38/17d35e9f82c271a560b59a12c152e0184854c7fb17184c34e87dbfbb187d/rumdl-0.2.34.tar.gz", hash = "sha256:8bdd81e746b2eca010f8d4f83422526d9dc229c3633ce9310d9cd13c66866399", size = 2876429, upload-time = "2026-07-14T20:25:46.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/ac/8c8f51343bd10b4bdad0e8ff21a79fcaabb90c622e8c42ff2e1e27b544c8/rumdl-0.2.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:372abcbe3b38790f244a1a07de97dc94663fca0eb51f9e7a6feebad0cd33f6ed", size = 6069702, upload-time = "2026-07-14T20:25:37.545Z" },
+    { url = "https://files.pythonhosted.org/packages/58/28/7ea8c22975763a8886f2687c77f72427b97ee5b1929575e13dab329fa191/rumdl-0.2.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a0407e12d80e842f23654ffb71062f15fd74991de716a6b28d0f114c490d805b", size = 5736309, upload-time = "2026-07-14T20:25:30.464Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7f/27505c1e104fc6df791f0bff7abc2ed4165c889b4df408d4fbda391c568a/rumdl-0.2.34-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d9fde9afe1edfb9624cc6b462a837f17aac1ede28d080a0b2794f67962c2e95a", size = 5841966, upload-time = "2026-07-14T20:25:33.192Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a5/bdedf3d1d4ac8e8aa4a7174fb2ee7dffdb1a3119dc2136efaaec8a7109f2/rumdl-0.2.34-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8d4eba122bc1076899ebba4c1e2c677a726076d96f05756342af7fc39c5cc48e", size = 6233057, upload-time = "2026-07-14T20:25:42.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/b8/65a408d86169c38e9e0d42bde134808c70ae9ea406d976507e66990f2ef1/rumdl-0.2.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ffcb9506da9601a0a6062cb0ea757439012882840283609493733f8a7742606c", size = 5837944, upload-time = "2026-07-14T20:25:35.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/54/e28f39966956266cd278e66d4ac36c3cc1c40aa81f8c30edd78c09cb51af/rumdl-0.2.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:253ec2716dc14d47b36eb5b45a2e524447fd675b846f44042b0bf77e86075492", size = 6220274, upload-time = "2026-07-14T20:25:44.403Z" },
+    { url = "https://files.pythonhosted.org/packages/60/18/a2f0ba36b8e78c6e639540c188076bcfd55aee918fbf4dfea76b1e98b051/rumdl-0.2.34-py3-none-win_amd64.whl", hash = "sha256:83f5591f6f37bd9a39212a3f3b0a7d183ad330e44c52a3471d2532ebdf4c14ff", size = 6171279, upload-time = "2026-07-14T20:25:39.691Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3611,6 +3659,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Migrate from Model A (ruff/rumdl pinned by pre-commit `rev:`) to local `uv run --locked` pre-commit hooks, making `uv.lock` the single source of truth for the lint toolchain.

## Type of Change

- [x] Other (please describe): build / CI / dependency tooling

## Motivation and Context

Dependabot has no pre-commit manager, so the `rev:` pins were frozen and never auto-updated. Routing the linters through `uv.lock` lets one grouped Dependabot PR update them in lockstep.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Synced from stateful-y/python-package-copier#128 via `copier update`. Preserves local customizations (`--extra mlflow`, `[tool.ty.rules]`, test deps, branding).
