### PR TITLE
chore: update from template v0.28.1

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -48,6 +48,7 @@ docs/_notebooks.py                   # build step split out of hooks.py; example
 docs/pages/reference/changelog.md   # one-line include of the root CHANGELOG.md
 docs/javascripts/mathjax.js
 docs/javascripts/readthedocs.js
+docs/material/templates/**                  # mkdocstrings template overrides; thin extends over the shipped _base/
 docs/material/overrides/api-index.html
 docs/material/overrides/api-page.html
 docs/material/overrides/api-submodule.html

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: e2a9246547438c7d13aa10b874af7cffd1e2d17c
+_commit: a5f1a20394a4da2ac910636e6d7fb5367a38acf5
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: a5f1a20394a4da2ac910636e6d7fb5367a38acf5
+_commit: 26fdfd9ed8bb34386f5ef13cc8a00e3bd51cad45
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -836,6 +836,36 @@ def _linkify_see_also(html, prefix):
     return _SEE_ALSO_BLOCK_RE.sub(_process_block, html)
 
 
+def _dedupe_heading_ids(html):
+    """Make repeated heading ids unique, keeping the first occurrence bare.
+
+    A page documenting more than one object -- a curated reference page with
+    several ``:::`` directives -- renders each of them at the same depth, so the
+    section templates give every one of them the same ids: two ``#see-also``,
+    two ``#parameters``. That is invalid HTML and makes the fragment ambiguous.
+
+    The templates cannot prevent it. Each ``:::`` is rendered independently and a
+    template has no way to know another object shares its page. Qualifying every
+    id with the object path would fix it and break every existing deep link into
+    the generated pages, which are single-object and vastly more numerous.
+
+    So the first occurrence keeps the bare id -- preserving those links -- and
+    later ones get a numeric suffix, which is what Python-Markdown's own toc
+    extension does for repeated markdown headings. Pages without duplicates are
+    returned unchanged, so this is inert for the single-object case.
+    """
+    seen = {}
+
+    def _rewrite(match):
+        prefix, hid, suffix = match.group(1), match.group(2), match.group(3)
+        seen[hid] = seen.get(hid, 0) + 1
+        if seen[hid] == 1:
+            return match.group(0)
+        return f"{prefix}{hid}_{seen[hid] - 1}{suffix}"
+
+    return re.sub(r'(<h[1-6][^>]*\sid=")([^"]+)(")', _rewrite, html)
+
+
 def _strip_redundant_section_titles(html):
     """Drop the section title the shipped mkdocstrings template still emits.
 
@@ -939,8 +969,19 @@ def on_page_content(html, page, config, files):
     # instead), so nothing downstream can consume the markup out from under it.
     html = _linkify_see_also(html, _site_root_prefix(page))
 
+    # NOT gated on `pages/api/generated/`. The templates render wherever a `:::`
+    # directive appears, including a curated reference page, so the duplicate
+    # title and the repeated ids appear there too. Gating these to the generated
+    # pages left a curated page showing each section title twice and carrying
+    # ambiguous fragments -- the same "it works where we looked" shape that once
+    # left See Also unlinked on exactly those pages. Both are no-ops on a page
+    # with no mkdocstrings output.
+    html = _strip_redundant_section_titles(html)
+    html = _dedupe_heading_ids(html)
+
+    # Still gated: this one derives the module path from the page's own filename
+    # (`pages/api/generated/{qualified}.md`), so it is meaningless elsewhere.
     if src.startswith("pages/api/generated/"):
-        html = _strip_redundant_section_titles(html)
         html = _add_source_links(html, page, config)
 
     # Keyed on the template a page declares, not on where the page happens to

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -487,22 +487,12 @@ def _get_git_ref():
     return _GIT_REF_CACHE
 
 
-# Numpydoc section types to surface in the TOC.
-_DOC_SECTION_TITLE_SLUGS = {
-    "Parameters": "parameters",
-    "Attributes": "attributes",
-    "Returns": "returns",
-    "Raises": "raises",
-    "Examples": "doc-examples",
-}
-_DETAIL_SECTION_SLUGS = {
-    "note": ("notes", "Notes"),
-    "see-also": ("see-also", "See Also"),
-    "references": ("references", "References"),
-}
-
-
-_SEE_ALSO_BLOCK_RE = re.compile(r'<details\s+class="see-also"[^>]*>.*?</details>', re.DOTALL)
+# The See Also container. This used to be `<details class="see-also">`, emitted by
+# mkdocstrings' shipped admonition template and dissolved later by a restructuring
+# pass -- which is why linkification had to run first. The template now emits a
+# heading plus this div, so there is nothing left to dissolve and no ordering
+# constraint. Keyed on the class the override emits; change one and change both.
+_SEE_ALSO_BLOCK_RE = re.compile(r'<div\s+class="[^"]*doc-admonition-see-also[^"]*"[^>]*>.*?</div>', re.DOTALL)
 # An entry's name sits at the START of its line -- mkdocstrings renders one entry
 # per line inside the paragraph. Anchoring here is what keeps a colon-terminated
 # word in an entry's DESCRIPTION ("Target : Note: see below") from being treated
@@ -790,10 +780,14 @@ def _linkify_glossary_terms(html, page, project_root):
 def _linkify_see_also(html, prefix):
     """Turn the names in a rendered See Also section into links.
 
-    Must run while the ``<details class="see-also">`` container still exists --
-    see the ordering comment in ``on_page_content``.  Unresolvable names are
-    left untouched: a docstring may reference a private helper or a concept,
-    and none of those are build errors.
+    Unresolvable names are left untouched: a docstring may reference a private
+    helper or a concept, and none of those are build errors.
+
+    This no longer has an ordering constraint. It used to have to run before the
+    restructuring pass, which dissolved the container it matches -- and getting
+    that order wrong silently degraded class-level sections while method-level
+    ones kept working. The container is now emitted by the admonition template
+    override and nothing consumes it.
     """
 
     def _process_block(block_match):
@@ -842,289 +836,64 @@ def _linkify_see_also(html, prefix):
     return _SEE_ALSO_BLOCK_RE.sub(_process_block, html)
 
 
-def _make_section_heading(slug, title, level=3):
-    """Build a heading element for an API page section."""
-    return (
-        f'<h{level} id="{slug}" class="doc-section-heading">{title}'
-        f'<a class="headerlink" href="#{slug}" '
-        f'title="Permanent link">&para;</a></h{level}>'
-    )
+def _strip_redundant_section_titles(html):
+    """Drop the section title the shipped mkdocstrings template still emits.
 
+    The docstring templates render every section title as
+    ``<p><span class="doc-section-title">Parameters:</span></p>``, and nothing in
+    the template layer can suppress it -- ``section.title`` falls back to a
+    translated string. Our dispatcher override emits a real heading for the same
+    sections, so without this the page shows each title twice.
 
-def _process_api_page_content(html, page, config):
-    """Convert numpydoc sections to h3 headings under mkdocstrings h2.
-
-    Restructures the rendered HTML produced by mkdocstrings so that
-    Parameters, Attributes, Returns, Raises, Notes, See Also,
-    References, and Source Code become proper ``<h3>`` headings.
-    The Source Code section is kept collapsible and preceded by a
-    link to the source file on GitHub.
-    For class pages a "Methods" heading is inserted before
-    ``doc-children`` and method headings are re-levelled h3 → h5.
-    Finally the page TOC is rebuilt to reflect the new structure.
+    Deliberately narrow: only the titles the dispatcher actually maps are
+    removed. A section it does not map (Yields, Warns, ...) keeps its title and
+    is untouched, so nothing loses its label. That set is the inverse of
+    ``doc_section_slugs`` in
+    ``docs/material/templates/python/material/docstring.html.jinja`` and the two
+    must stay in sync -- adding a heading there without adding its title here
+    renders it twice; the reverse renders it not at all.
     """
-    from mkdocs.structure.toc import AnchorLink
+    titles = "|".join(re.escape(t) for t in ("Parameters", "Attributes", "Returns", "Raises", "Examples"))
+    return re.sub(
+        rf'<p>\s*<span class="doc-section-title">\s*(?:{titles}):?\s*</span>\s*</p>\s*',
+        "",
+        html,
+    )
 
-    is_class_page = bool(re.search(r'<h3\s+id="kedro_azureml_pipeline\.', html))
 
-    # Locate class-level content region
-    h2_match = re.search(r'<h2\s+id="kedro_azureml_pipeline\.', html)
-    if not h2_match:
+def _add_source_links(html, page, config):
+    """Insert a "View on GitHub" link after each Source Code heading.
+
+    This is the one part of the old restructuring pass that genuinely cannot move
+    into a template: it needs ``repo_url`` and a git ref, and a mkdocstrings
+    template receives the handler's options, not the mkdocs config. The heading
+    itself IS template-owned (see ``class.html.jinja`` / ``function.html.jinja``);
+    only the link is inserted here.
+
+    Keyed on the heading's id rather than its text, because the text is
+    translatable and the id is the thing we control.
+    """
+    repo_url = config.get("repo_url", "").rstrip("/")
+    if not repo_url:
         return html
-    h2_pos = h2_match.start()
 
-    if is_class_page:
-        boundary_match = re.search(r'<div\s+class="doc doc-children"', html[h2_pos:])
-        boundary_pos = h2_pos + boundary_match.start() if boundary_match else len(html)
-    else:
-        boundary_pos = len(html)
-
-    class_region = html[h2_pos:boundary_pos]
-    sections_found = []  # (id, title) in document order
-
-    # Convert doc-section-title spans to h3 headings
-    def _span_to_h3(m):
-        title = re.sub(r"<[^>]+>", "", m.group(1)).strip().rstrip(":")
-        slug = _DOC_SECTION_TITLE_SLUGS.get(title)
-        if slug:
-            sections_found.append((slug, title))
-            return _make_section_heading(slug, title)
-        return m.group(0)
-
-    new_class_region = re.sub(
-        r"<p>\s*<span\s+class=\"doc-section-title\"[^>]*>(.*?)</span>\s*</p>",
-        _span_to_h3,
-        class_region,
+    # pages/api/generated/{qualified}.md -> package/module.py
+    qualified = page.file.src_path.split("/")[-1].removesuffix(".md")
+    parts = qualified.split(".")
+    if len(parts) < 2:
+        return html
+    module_path = "/".join(parts[:-1])
+    link = (
+        f'<p class="github-source-link">'
+        f'<a href="{repo_url}/blob/{_get_git_ref()}/src/{module_path}.py">View on GitHub</a></p>'
     )
 
-    # Convert <details> sections to h3 heading + unwrapped content
-    for detail_cls, (slug, title) in _DETAIL_SECTION_SLUGS.items():
-        detail_re = re.compile(
-            rf'<details\s+class="{re.escape(detail_cls)}"[^>]*>'
-            rf"\s*<summary>{re.escape(title)}</summary>"
-            rf"(.*?)</details>",
-            re.DOTALL,
-        )
-        m = detail_re.search(new_class_region)
-        if m:
-            heading = _make_section_heading(slug, title)
-            inner = m.group(1).strip()
-            new_class_region = new_class_region[: m.start()] + heading + "\n" + inner + new_class_region[m.end() :]
-            sections_found.append((slug, title))
-
-    # Convert <details class="mkdocstrings-source"> to collapsible Source Code
-    # with a GitHub link preceding the code block
-    src_re = re.compile(
-        r'<details\s+class="mkdocstrings-source"[^>]*>'
-        r"\s*<summary>.*?</summary>"
-        r"(.*?)</details>",
-        re.DOTALL,
+    return re.sub(
+        r'(<h[35][^>]*id="[^"]*source-code"[^>]*>.*?</h[35]>)',
+        lambda m: m.group(1) + link,
+        html,
+        flags=re.DOTALL,
     )
-    src_m = src_re.search(new_class_region)
-    if src_m:
-        heading = _make_section_heading("source-code", "Source Code")
-        inner = src_m.group(1).strip()
-
-        # Build GitHub source link from page path and config
-        github_link = ""
-        repo_url = config.get("repo_url", "").rstrip("/")
-        if repo_url:
-            # Extract qualified name from page source path
-            src_path = page.file.src_path  # pages/api/generated/{qualified}.md
-            qualified = src_path.split("/")[-1].removesuffix(".md")
-            # qualified = package.module.Name → module path = package/module.py
-            parts = qualified.split(".")
-            if len(parts) >= 2:
-                module_path = "/".join(parts[:-1])
-                git_ref = _get_git_ref()
-                github_link = (
-                    f'<p class="github-source-link">'
-                    f'<a href="{repo_url}/blob/{git_ref}/src/{module_path}.py">'
-                    f"View on GitHub</a></p>\n"
-                )
-
-        source_block = (
-            heading
-            + "\n"
-            + github_link
-            + '<details class="source-code-details">\n'
-            + "<summary>Show/Hide source</summary>\n"
-            + inner
-            + "\n"
-            + "</details>"
-        )
-        new_class_region = new_class_region[: src_m.start()] + source_block + new_class_region[src_m.end() :]
-        sections_found.append(("source-code", "Source Code"))
-
-    html = html[:h2_pos] + new_class_region + html[boundary_pos:]
-
-    # Insert "Methods" h3 before doc-children
-    if is_class_page:
-        methods_heading = _make_section_heading("methods", "Methods") + "\n"
-        html = re.sub(
-            r'(<div\s+class="doc doc-children")',
-            methods_heading + r"\1",
-            html,
-            count=1,
-        )
-
-    # Increase method heading levels (h3 -> h4) in doc-children
-    if is_class_page:
-        dc_match = re.search(r'<div\s+class="doc doc-children"', html)
-        if dc_match:
-            before = html[: dc_match.start()]
-            after = html[dc_match.start() :]
-            after = re.sub(r"<h3(\s)", r"<h4\1", after)
-            after = re.sub(r"</h3>", "</h4>", after)
-            html = before + after
-
-    # Process method numpydoc sections and source code in doc-children
-    if is_class_page:
-        dc_match2 = re.search(r'<div\s+class="doc doc-children"', html)
-        if dc_match2:
-            dc_start = dc_match2.start()
-            dc_content = html[dc_start:]
-
-            # Build GitHub link once (same source file for all methods)
-            method_github_link = ""
-            repo_url = config.get("repo_url", "").rstrip("/")
-            if repo_url:
-                _src_path = page.file.src_path
-                _qualified = _src_path.split("/")[-1].removesuffix(".md")
-                _parts = _qualified.split(".")
-                if len(_parts) >= 2:
-                    _module_path = "/".join(_parts[:-1])
-                    _git_ref = _get_git_ref()
-                    method_github_link = (
-                        f'<p class="github-source-link">'
-                        f'<a href="{repo_url}/blob/{_git_ref}/src/{_module_path}.py">'
-                        f"View on GitHub</a></p>\n"
-                    )
-
-            # Find all method headings (h4) with their IDs
-            method_positions = [(m.start(), m.group(1)) for m in re.finditer(r'<h4\s+id="([^"]+)"', dc_content)]
-
-            if method_positions:
-                new_dc = dc_content[: method_positions[0][0]]
-                for idx, (pos, method_id) in enumerate(method_positions):
-                    end_pos = method_positions[idx + 1][0] if idx + 1 < len(method_positions) else len(dc_content)
-                    method_short = method_id.split(".")[-1]
-                    section = dc_content[pos:end_pos]
-
-                    # Convert numpydoc section-title spans to h5 headings
-                    def _method_span_to_h5(m, _ms=method_short):
-                        title = re.sub(r"<[^>]+>", "", m.group(1)).strip().rstrip(":")
-                        base_slug = _DOC_SECTION_TITLE_SLUGS.get(title)
-                        if base_slug:
-                            slug = f"{_ms}-{base_slug}"
-                            return _make_section_heading(slug, title, level=5)
-                        return m.group(0)
-
-                    section = re.sub(
-                        r"<p>\s*<span\s+class=\"doc-section-title\"[^>]*>(.*?)</span>\s*</p>",
-                        _method_span_to_h5,
-                        section,
-                    )
-
-                    # Convert detail sections (Notes, See Also, References) to h6
-                    for detail_cls, (base_slug, title) in _DETAIL_SECTION_SLUGS.items():
-                        _slug = f"{method_short}-{base_slug}"
-                        detail_re_m = re.compile(
-                            rf'<details\s+class="{re.escape(detail_cls)}"[^>]*>'
-                            rf"\s*<summary>{re.escape(title)}</summary>"
-                            rf"(.*?)</details>",
-                            re.DOTALL,
-                        )
-                        dm = detail_re_m.search(section)
-                        if dm:
-                            heading = _make_section_heading(_slug, title, level=5)
-                            inner = dm.group(1).strip()
-                            section = section[: dm.start()] + heading + "\n" + inner + section[dm.end() :]
-
-                    # Convert source code to collapsible block with GitHub link
-                    method_src_re = re.compile(
-                        r'<details\s+class="mkdocstrings-source"[^>]*>'
-                        r"\s*<summary>.*?</summary>"
-                        r"(.*?)</details>",
-                        re.DOTALL,
-                    )
-                    msrc_m = method_src_re.search(section)
-                    if msrc_m:
-                        _slug = f"{method_short}-source-code"
-                        heading = _make_section_heading(_slug, "Source Code", level=5)
-                        inner = msrc_m.group(1).strip()
-                        source_block = (
-                            heading
-                            + "\n"
-                            + method_github_link
-                            + '<details class="source-code-details">\n'
-                            + "<summary>Show/Hide source</summary>\n"
-                            + inner
-                            + "\n"
-                            + "</details>"
-                        )
-                        section = section[: msrc_m.start()] + source_block + section[msrc_m.end() :]
-
-                    new_dc += section
-
-                html = html[:dc_start] + new_dc
-
-    # Rename "Examples" h2 to "Tutorials" h3
-    examples_h2 = re.search(r'<h2 id="examples">.*?</h2>', html, re.DOTALL)
-    if examples_h2:
-        old = examples_h2.group(0)
-        new = (
-            old
-            .replace('<h2 id="examples">', '<h3 id="tutorials">')
-            .replace("</h2>", "</h3>")
-            .replace(">Examples<", ">Tutorials<")
-            .replace("#examples", "#tutorials")
-        )
-        html = html.replace(old, new, 1)
-
-    # Rebuild page.toc
-    old_toc = list(page.toc)
-    if old_toc:
-        h1 = old_toc[0]
-        old_h2s = list(h1.children)
-
-        # The first h2 child is the mkdocstrings class/func heading
-        if old_h2s:
-            main_h2 = old_h2s[0]
-
-        # All sections nest inside the mkdocstrings h2
-        section_children = []
-
-        # Numpydoc + detail + source code sections (level 3)
-        for slug, title in sections_found:
-            section_children.append(AnchorLink(title=title, id=slug, level=3))
-
-        # Methods with individual methods nested underneath (level 3 + 4)
-        if is_class_page:
-            methods_entry = AnchorLink(title="Methods", id="methods", level=3)
-            # Recover method names from the HTML h4 headings
-            dc_match_toc = re.search(r'<div\s+class="doc doc-children"', html)
-            if dc_match_toc:
-                for m_toc in re.finditer(r'<h4[^>]+id="([^"]+)"[^>]*>', html[dc_match_toc.start() :]):
-                    method_id = m_toc.group(1)
-                    method_short = method_id.split(".")[-1]
-                    badge = '<code class="doc-symbol doc-symbol-method"></code> '
-                    methods_entry.children.append(AnchorLink(title=badge + method_short, id=method_id, level=4))
-            section_children.append(methods_entry)
-
-        # Tutorials (level 3)
-        for h2 in old_h2s[1:]:
-            if h2.id in ("examples", "tutorials"):
-                section_children.append(AnchorLink(title="Tutorials", id="tutorials", level=3))
-                break
-
-        if old_h2s:
-            main_h2.children = section_children
-            h1.children = [main_h2]
-        else:
-            h1.children = section_children
-
-    return html
 
 
 def on_config(config):
@@ -1151,7 +920,7 @@ def on_config(config):
 
 
 def on_page_content(html, page, config, files):
-    """Post-process HTML: API page TOC and content restructuring."""
+    """Post-process rendered HTML: See Also links, glossary links, API sidebar."""
     src = page.file.src_path
 
     # Keyed on the markup, not on where the page lives: mkdocstrings emits a See
@@ -1161,17 +930,18 @@ def on_page_content(html, page, config, files):
     # page rendered three entries as plain text while the same names linked fine
     # on the generated pages, which is exactly the shape of "it works where we
     # looked". --strict never sees it: this is our own HTML.
-
+    #
+    # There is no ordering constraint here any more. There used to be: a
+    # restructuring pass dissolved the `<details class="see-also">` container
+    # this linkifier matched, so linkifying afterwards silently did nothing for
+    # class-level sections -- the majority -- while appearing to work for
+    # method-level ones. The container is gone (the templates emit a heading
+    # instead), so nothing downstream can consume the markup out from under it.
     html = _linkify_see_also(html, _site_root_prefix(page))
 
-    # Process generated API member pages (per-class/function detail pages)
     if src.startswith("pages/api/generated/"):
-        # ORDER IS LOAD-BEARING: mkdocstrings emits See Also as a
-        # <details class="see-also"> block, and _process_api_page_content
-        # dissolves that block for class-level docstrings.  Linkifying after it
-        # silently does nothing for class-level See Also sections -- the
-        # majority of them -- while appearing to work for method-level ones.
-        html = _process_api_page_content(html, page, config)
+        html = _strip_redundant_section_titles(html)
+        html = _add_source_links(html, page, config)
 
     # Keyed on the template a page declares, not on where the page happens to
     # live: the index is wherever a project put it. Matching a hardcoded
@@ -1180,8 +950,6 @@ def on_page_content(html, page, config, files):
     if page.meta.get("template") in ("api-index.html", "api-submodule.html"):
         page.meta["module_toc"] = _build_module_toc(config, current_src_path=src, prefix=_site_root_prefix(page))
 
-    # Last: the API restructuring above rewrites whole regions, so linking
-    # before it would have its links discarded with the markup they sat in.
     html = _linkify_glossary_terms(html, page, Path(__file__).parent.parent)
 
     return html

--- a/docs/material/templates/python/material/class.html.jinja
+++ b/docs/material/templates/python/material/class.html.jinja
@@ -1,0 +1,67 @@
+{#- Give a class's Source Code and Methods sections real headings.
+
+Both are anchors today (`#source-code`, `#methods`) that the hooks invented with
+a regex after the `toc` extension had run, which is why `page.toc` had to be
+rebuilt by hand. Emitting them here registers them for the table of contents
+automatically.
+
+`{{ super() }}` is doing the work: this file overrides only the two block
+*openings* and defers the bodies to the shipped template, so nothing upstream is
+copied and upstream fixes keep arriving. Extending `_base/class.html.jinja`
+rather than replacing it is what makes that possible -- the shipped
+`material/class.html.jinja` is a one-line stub over `_base/`, and this file
+takes that stub's place.
+
+The "View on GitHub" link is deliberately NOT here: it needs `repo_url` and a
+git ref, and a mkdocstrings template receives the handler's options, not the
+mkdocs config. The hooks insert it after this heading. That split is stated
+rather than accidental.
+-#}
+{% extends "_base/class.html.jinja" %}
+
+{% block source scoped %}
+  {#- Guarded on the same config the shipped block guards its body with:
+      without this, a project that turns off `show_source` would get a heading
+      introducing nothing. -#}
+  {% if config.show_source %}
+    {% filter heading(
+         3 if heading_level == 2 else 5,
+         id="source-code" if heading_level == 2 else (obj.name ~ "-source-code"),
+         toc_label="Source Code",
+       ) %}
+      <span class="doc-section-heading">Source Code</span>
+    {% endfilter %}
+  {% endif %}
+  {{ super() }}
+{% endblock source %}
+
+{% block children scoped %}
+  {#- Only a class that actually renders members gets a Methods heading; an
+      empty one would introduce nothing and add a dead TOC entry. -#}
+  {% if config.members is not false and obj.members %}
+    {% filter heading(3, id="methods", toc_label="Methods") %}
+      <span class="doc-section-heading">Methods</span>
+    {% endfilter %}
+  {% endif %}
+  {#- Deliberately +2, where the shipped block uses +1.
+
+      The page nests h1 title > h2 class > h3 sections, and "Methods" above is
+      one of those h3 sections. A member must therefore start at h4, so it sits
+      UNDER the heading that introduces it rather than beside it. With the
+      shipped +1 a method renders h3 -- level-equal to "Methods" -- which reads
+      as a sibling and flattens the sidebar.
+
+      This is what the old hooks achieved by regex (`<h3` -> `<h4` inside
+      `doc-children`, then the member's own sections `<h3` -> `<h5`). Setting the
+      level here instead lets mkdocstrings' HeadingShiftingTreeprocessor do the
+      shift, which is the machinery that already exists for exactly this.
+
+      The three lines below are the shipped block's body, copied rather than
+      deferred to `super()`: the level is set *inside* that block, so there is no
+      way to influence it from out here. Copying three lines is the smaller evil
+      -- but it is a copy, so check it on a mkdocstrings bump. -#}
+  {% set root = False %}
+  {% set heading_level = heading_level + 2 %}
+  {% include "children.html.jinja" with context %}
+{% endblock children %}
+

--- a/docs/material/templates/python/material/class.html.jinja
+++ b/docs/material/templates/python/material/class.html.jinja
@@ -36,9 +36,29 @@ rather than accidental.
 {% endblock source %}
 
 {% block children scoped %}
-  {#- Only a class that actually renders members gets a Methods heading; an
-      empty one would introduce nothing and add a dead TOC entry. -#}
-  {% if config.members is not false and obj.members %}
+  {#- Only a class that actually renders methods gets a Methods heading.
+
+      `obj.members` is the WRONG set to test and was the first guard here: it is
+      the pre-filter membership and counts attributes, so every attributes-only
+      class -- a pydantic config model, an Enum, a dataclass -- got a heading
+      introducing nothing plus a dead ToC entry. Measured at 12 of 25 class pages
+      in one repo before this was fixed. `--strict` cannot see it: the anchor
+      resolves, it just leads nowhere.
+
+      This mirrors what `children.html.jinja` actually renders: functions after
+      `filter_objects`, minus `__init__` when it is merged into the class. A
+      namespace is needed because a `{% set %}` inside `{% if %}` is scoped to
+      the branch and would not update the outer name. -#}
+  {% set _ns = namespace(methods=obj.functions|filter_objects(
+       filters=config.filters,
+       members_list=none,
+       inherited_members=config.inherited_members,
+       keep_no_docstrings=config.show_if_no_docstring,
+     )|list) %}
+  {% if config.merge_init_into_class %}
+    {% set _ns.methods = _ns.methods|rejectattr("name", "equalto", "__init__")|list %}
+  {% endif %}
+  {% if config.members is not false and _ns.methods %}
     {% filter heading(3, id="methods", toc_label="Methods") %}
       <span class="doc-section-heading">Methods</span>
     {% endfilter %}

--- a/docs/material/templates/python/material/class.html.jinja
+++ b/docs/material/templates/python/material/class.html.jinja
@@ -64,4 +64,3 @@ rather than accidental.
   {% set heading_level = heading_level + 2 %}
   {% include "children.html.jinja" with context %}
 {% endblock children %}
-

--- a/docs/material/templates/python/material/docstring.html.jinja
+++ b/docs/material/templates/python/material/docstring.html.jinja
@@ -100,4 +100,3 @@ reason the two must stay in sync.
     {% endfor %}
   {% endwith %}
 {% endif %}
-

--- a/docs/material/templates/python/material/docstring.html.jinja
+++ b/docs/material/templates/python/material/docstring.html.jinja
@@ -1,0 +1,103 @@
+{#- Emit a real heading before each docstring section this project surfaces.
+
+This overrides mkdocstrings' section *dispatcher*, not the section templates
+themselves. That distinction is the whole design:
+
+  - A section's title lives INSIDE its style block (`table_style` and friends),
+    so overriding `parameters.html.jinja` to change one line means copying its
+    57-line table. Across the eight table-style templates that is ~271 lines of
+    forked upstream markup -- more than the regex pass it replaces, and it stops
+    receiving upstream fixes silently.
+  - Emitting the heading here instead leaves all nine section templates
+    untouched, so they keep getting upstream fixes.
+
+A heading emitted with the `heading` filter is registered for the table of
+contents by mkdocstrings itself (`mkdocstrings_headings_list` records it,
+`get_headings()` hands it to the outer layer, `_HeadingsPostProcessor` removes
+the duplicate). That is why this file exists at all: the hooks used to invent
+these headings with a regex AFTER the `toc` extension had run, so nothing could
+see them, and `page.toc` had to be rebuilt by hand with `AnchorLink` objects.
+Emit them here and that whole apparatus is unnecessary.
+
+Only the sections listed below get headings. That set is not arbitrary -- it
+mirrors exactly what the hooks used to surface, so the page's anchor set is
+unchanged. Adding a kind here ADDS an anchor, which is a URL, so treat it as a
+breaking link change rather than a tidy-up.
+
+The shipped section template still writes its own
+`<p><span class="doc-section-title">...</span></p>`; nothing in the template
+layer can suppress it (`section.title` falls back to a translated string). The
+hooks strip exactly the titles named here -- the inverse of this map, and the
+reason the two must stay in sync.
+-#}
+{% set doc_section_slugs = {
+     "parameters": ("parameters", "Parameters"),
+     "attributes": ("attributes", "Attributes"),
+     "returns": ("returns", "Returns"),
+     "raises": ("raises", "Raises"),
+     "examples": ("doc-examples", "Examples"),
+   } %}
+{% set admonition_slugs = {
+     "note": ("notes", "Notes"),
+     "see-also": ("see-also", "See Also"),
+     "references": ("references", "References"),
+   } %}
+{% if docstring_sections %}
+  {% block logs scoped %}
+    {{ log.debug("Rendering docstring") }}
+  {% endblock logs %}
+  {% with autoref_hook = AutorefsHook(obj, config) %}
+    {% for section in docstring_sections %}
+      {#- The page's own object renders at heading_level 2, its members deeper.
+          Class-level sections are bare (`#parameters`); a member's are prefixed
+          with its name (`#greet-parameters`), which is the scheme the hooks
+          built by string concatenation. -#}
+      {%- set at_root = heading_level == 2 -%}
+      {%- if section.kind.value == "admonition" -%}
+        {%- set mapped = admonition_slugs.get(section.value.kind) -%}
+      {%- else -%}
+        {%- set mapped = doc_section_slugs.get(section.kind.value) -%}
+      {%- endif -%}
+      {%- if mapped -%}
+        {%- set section_id = mapped[0] if at_root else (obj.name ~ "-" ~ mapped[0]) -%}
+        {% filter heading(3 if at_root else 5, id=section_id, toc_label=mapped[1]) %}
+          <span class="doc-section-heading">{{ mapped[1] }}</span>
+        {% endfilter %}
+      {%- endif -%}
+      {% if config.show_docstring_description and section.kind.value == "text" %}
+        {{ section.value|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+      {% elif config.show_docstring_attributes and section.kind.value == "attributes" %}
+        {% include "docstring/attributes.html.jinja" with context %}
+      {% elif config.show_docstring_functions and section.kind.value == "functions" %}
+        {% include "docstring/functions.html.jinja" with context %}
+      {% elif config.show_docstring_classes and section.kind.value == "classes" %}
+        {% include "docstring/classes.html.jinja" with context %}
+      {% elif config.show_docstring_type_aliases and section.kind.value == "type aliases" %}
+        {% include "docstring/type_aliases.html.jinja" with context %}
+      {% elif config.show_docstring_modules and section.kind.value == "modules" %}
+        {% include "docstring/modules.html.jinja" with context %}
+      {% elif config.show_docstring_type_parameters and section.kind.value == "type parameters" %}
+        {% include "docstring/type_parameters.html.jinja" with context %}
+      {% elif config.show_docstring_parameters and section.kind.value == "parameters" %}
+        {% include "docstring/parameters.html.jinja" with context %}
+      {% elif config.show_docstring_other_parameters and section.kind.value == "other parameters" %}
+        {% include "docstring/other_parameters.html.jinja" with context %}
+      {% elif config.show_docstring_raises and section.kind.value == "raises" %}
+        {% include "docstring/raises.html.jinja" with context %}
+      {% elif config.show_docstring_warns and section.kind.value == "warns" %}
+        {% include "docstring/warns.html.jinja" with context %}
+      {% elif config.show_docstring_yields and section.kind.value == "yields" %}
+        {% include "docstring/yields.html.jinja" with context %}
+      {% elif config.show_docstring_receives and section.kind.value == "receives" %}
+        {% include "docstring/receives.html.jinja" with context %}
+      {% elif config.show_docstring_returns and section.kind.value == "returns" %}
+        {% include "docstring/returns.html.jinja" with context %}
+      {% elif config.show_docstring_examples and section.kind.value == "examples" %}
+        {% include "docstring/examples.html.jinja" with context %}
+      {% elif config.show_docstring_description and section.kind.value == "admonition" %}
+        {% include "docstring/admonition.html.jinja" with context %}
+      {% endif %}
+    {% endfor %}
+  {% endwith %}
+{% endif %}
+

--- a/docs/material/templates/python/material/docstring/admonition.html.jinja
+++ b/docs/material/templates/python/material/docstring/admonition.html.jinja
@@ -24,4 +24,3 @@ still render their title here, so nothing loses its label.
 <div class="doc-section-item doc-admonition-{{ section.value.kind }}">
   {{ section.value.contents|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
 </div>
-

--- a/docs/material/templates/python/material/docstring/admonition.html.jinja
+++ b/docs/material/templates/python/material/docstring/admonition.html.jinja
@@ -1,0 +1,27 @@
+{#- Render a docstring admonition as plain content, not a collapsible block.
+
+The shipped template wraps every admonition in
+`<details class="{{ section.value.kind }}" open>`. That one element is what the
+hooks' `_SEE_ALSO_BLOCK_RE` existed to find, and dissolving it was what forced
+`_linkify_see_also` to run BEFORE the restructuring pass -- an ordering the
+hooks called out as load-bearing, where getting it wrong silently degraded
+class-level See Also sections (the majority) while method-level ones kept
+working. Emitting the content directly removes the container, and with it the
+ordering constraint.
+
+The heading comes from the dispatcher (`docstring.html.jinja`), which is also
+what registers it for the table of contents. Kinds the dispatcher does not map
+still render their title here, so nothing loses its label.
+-#}
+{% block logs scoped %}
+  {{ log.debug("Rendering admonition") }}
+{% endblock logs %}
+
+{% set _mapped_kinds = ["note", "see-also", "references"] %}
+{% if section.value.kind not in _mapped_kinds %}
+  <p><span class="doc-section-title">{{ section.title|convert_markdown(heading_level, html_id, strip_paragraph=True, autoref_hook=autoref_hook) }}</span></p>
+{% endif %}
+<div class="doc-section-item doc-admonition-{{ section.value.kind }}">
+  {{ section.value.contents|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+</div>
+

--- a/docs/material/templates/python/material/function.html.jinja
+++ b/docs/material/templates/python/material/function.html.jinja
@@ -1,0 +1,26 @@
+{#- Give a function's Source Code section a real heading.
+
+Same reasoning as `class.html.jinja`: the anchor exists today (`#source-code` on
+a function page, `#<method>-source-code` for a class member) but was invented by
+a regex after `toc` had run, so it never reached the table of contents on its
+own. `{{ super() }}` defers the block body to the shipped template.
+
+A function rendered as a class member arrives here with a deeper
+`heading_level`, which is what selects the prefixed id -- the same rule the
+hooks applied by string concatenation.
+-#}
+{% extends "_base/function.html.jinja" %}
+
+{% block source scoped %}
+  {% if config.show_source %}
+    {% filter heading(
+         3 if heading_level == 2 else 5,
+         id="source-code" if heading_level == 2 else (obj.name ~ "-source-code"),
+         toc_label="Source Code",
+       ) %}
+      <span class="doc-section-heading">Source Code</span>
+    {% endfilter %}
+  {% endif %}
+  {{ super() }}
+{% endblock source %}
+

--- a/docs/material/templates/python/material/function.html.jinja
+++ b/docs/material/templates/python/material/function.html.jinja
@@ -23,4 +23,3 @@ hooks applied by string concatenation.
   {% endif %}
   {{ super() }}
 {% endblock source %}
-

--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -370,8 +370,19 @@ div.dt-container .dt-paging .dt-paging-button.disabled:active {
   color: var(--md-accent-fg-color);
 }
 
-/* Override Material h5 styling for API doc section headings */
-h5.doc-section-heading {
+/* Override Material's h5 styling for API doc section headings.
+ *
+ * A DESCENDANT selector, not `h5.doc-section-heading`. The class used to sit on
+ * the heading itself, when a hook synthesised the element; the templates that
+ * replaced it wrap the text in `<h5 id="..."><span class="doc-section-heading">`,
+ * so the old selector matched nothing and Material's default
+ * `.md-typeset h5 {text-transform: uppercase; font-size: .8em}` reasserted on
+ * every method-level section heading -- 40 of them on two pages in one repo,
+ * with a green build and no warning, because CSS that matches nothing is silent.
+ *
+ * Both forms are matched so this does not depend on where the class lands. */
+h5.doc-section-heading,
+h5 .doc-section-heading {
   text-transform: none;
   font-size: 1em;
   color: var(--md-default-fg-color);

--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -377,14 +377,20 @@ h5.doc-section-heading {
   color: var(--md-default-fg-color);
 }
 
-/* Collapsible source code details */
-.source-code-details {
+/* Collapsible source code block.
+ *
+ * Keyed on mkdocstrings' own `.mkdocstrings-source`, not a class of ours. The
+ * hooks used to rewrite that element into `<details class="source-code-details">`;
+ * the templates now leave mkdocstrings' markup alone, so the selector follows it.
+ * A stale selector here is invisible -- the page renders unstyled and the build
+ * stays green -- so this moved in the same commit as the markup. */
+.mkdocstrings-source {
   margin: 0.5em 0 1em;
   border: 0.05rem solid var(--md-typeset-table-color);
   border-radius: 0.2rem;
 }
 
-.source-code-details > summary {
+.mkdocstrings-source > summary {
   display: block;
   padding: 0.5em 0.8em;
   font-size: 0.72rem;
@@ -397,27 +403,27 @@ h5.doc-section-heading {
   list-style: none;
 }
 
-.source-code-details > summary::before {
+.mkdocstrings-source > summary::before {
   content: "\25B6\FE0E";   /* right-pointing triangle */
   display: inline-block;
   margin-right: 0.4em;
   transition: transform 0.2s;
 }
 
-.source-code-details[open] > summary::before {
+.mkdocstrings-source[open] > summary::before {
   transform: rotate(90deg);
 }
 
-.source-code-details > summary::-webkit-details-marker {
+.mkdocstrings-source > summary::-webkit-details-marker {
   display: none;
 }
 
-.source-code-details > summary:hover {
+.mkdocstrings-source > summary:hover {
   color: var(--md-accent-fg-color);
   background: var(--md-default-bg-color--lightest);
 }
 
-.source-code-details pre {
+.mkdocstrings-source pre {
   margin: 0 !important;
   border-radius: 0 0 0.2rem 0.2rem;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,14 @@ markdown_extensions:
   - sane_lists
   - toc:
       permalink: true
+      # API member pages carry two levels of section heading: the class's own
+      # (h3) and each method's (h5). Only the first belongs in the table of
+      # contents -- listing every method's Parameters/Returns/Source Code turns a
+      # class page's ToC into a wall. The hooks used to get this by building
+      # `page.toc` by hand and simply not adding them; now that the headings are
+      # real, `toc_depth` is what draws the same line. The h5 anchors still
+      # exist and are still linkable -- this only controls what the sidebar lists.
+      toc_depth: 4
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.betterem:
@@ -137,6 +145,15 @@ plugins:
   - tags
   - autorefs
   - mkdocstrings:
+      custom_templates: docs/material/templates
+      # Overrides live in docs/material/templates/python/material/. Each one is a
+      # thin `{% extends %}` over the shipped `_base/` template, so upstream
+      # fixes keep arriving -- see the header comments in those files for why the
+      # dispatcher is overridden rather than the nine section templates.
+      #
+      # NOTE: this is a PLUGIN-level key, not a handler option. Putting it under
+      # `handlers.python.options` fails the build with
+      # `PythonOptions.__init__() got an unexpected keyword argument`.
       handlers:
         python:
           paths: [src]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,14 @@ exclude_docs: |
   # four modules instead of one, which is what made it visible.
   *.py
   __pycache__/
+  # Same reason, one directory over: `docs/material/templates/` holds
+  # mkdocstrings template overrides, which are build tooling, not pages. Without
+  # this they are published as static assets -- confirmed live, `class.html.jinja`
+  # served 200 from the docs site. `material/overrides/*.html` leaks the same way
+  # and is excluded here too; `api-submodule.html` above was the one instance of
+  # this that had been noticed before, handled one file at a time.
+  *.jinja
+  material/overrides/*.html
 
 
 not_in_nav: |


### PR DESCRIPTION
Updates the project from template v0.27.3 to **[v0.28.1](https://github.com/stateful-y/python-package-copier/releases/tag/v0.28.1)** (`26fdfd9`), folding [v0.28.0](https://github.com/stateful-y/python-package-copier/releases/tag/v0.28.0) (`a5f1a20`, [#189](https://github.com/stateful-y/python-package-copier/pull/189)) and the v0.28.1 follow-up into one PR.

API page structure now comes from mkdocstrings template overrides instead of regex over rendered HTML. `_process_api_page_content` (283 lines) and the hand-built `page.toc`/`AnchorLink` rebuild are gone; `docs/hooks.py` no longer imports mkdocs at all.

| file | change |
|---|---|
| `docs/material/templates/python/material/` | **new** — 4 overrides (`class`, `function`, `docstring`, `docstring/admonition`), each a thin `{% extends %}` over the shipped `_base/` |
| `docs/hooks.py` | 1227 → 1038 lines |
| `docs/stylesheets/theme.css` | 7 selectors follow the markup: `.source-code-details` → `.mkdocstrings-source`; `h5` section-heading rule becomes a descendant selector |
| `mkdocs.yml` | `toc_depth: 4`, plugin-level `custom_templates:`, and `exclude_docs` gains `*.jinja` + `material/overrides/*.html`. **Zero nav lines changed.** |
| `.claude/skills/.../file-classification.md` | new Tier 1 entry |

The pre-update tree was snapshotted and every touched file whole-file diffed against it. The change matches the pristine render delta exactly — nothing else.

## What v0.28.1 folds in

The v0.28.0 fan-out found five defects across the fleet. v0.28.1 fixes all five upstream, so **this PR now carries no local workaround.** The v0.28.1 delta is exactly 7 files and is identical for `include_examples: True` and `False`, so it is not inert here.

Each fix was verified by measurement in both directions, not assumed.

### 1. Trailing blank line at EOF — **fixed upstream, local workaround reverted**

The four overrides rendered with a blank line at EOF, so `end-of-file-fixer` went red on a clean update. The sources now close with `{%- endraw %}`.

Measured on the rendered tree, not the source — the source was correct all along, which is what made this easy to misdiagnose:

| | files ending in a blank line |
|---|---|
| pristine `copier copy --vcs-ref v0.28.0` | **4** (all four overrides) |
| pristine `copier copy --vcs-ref v0.28.1` | **0** |

The earlier commit on this branch that stripped the blank line by hand is now superseded. **All four override files are byte-identical to a pristine `copier copy --vcs-ref v0.28.1` render**, verified by `cmp` per file, and 0 tracked files in the repo end in a blank line. No local delta remains on any of them.

### 2. Overrides published as static assets — fixed

`exclude_docs` gained `*.jinja` and `material/overrides/*.html`.

| | before | after |
|---|---|---|
| `*.jinja` under `site/` | 4 | **0** |
| files under `site/material/` | 7 | **0** |
| built HTML pages | 84 | 81 |

The three fewer pages are the `material/overrides/*.html` fragments, which have no `<article>` and so never contributed anchors — the anchor count is unaffected by their removal.

Live confirmation on this PR's RTD preview, which served them at **200** before this commit:

- `…/material/templates/python/material/class.html.jinja`
- `…/material/overrides/main.html`

### 3. Empty `Methods` heading on attributes-only classes — fixed

The guard tested `obj.members`, the **pre-filter** set, which counts attributes. It now runs `filter_objects` over `obj.functions`.

| | before | after |
|---|---|---|
| pages with `id="methods"` | 25 | **12** |

Swept **every** class page, both directions:

- **13 pages lost `#methods`.** Every one renders **zero** methods — all 10 pydantic config models, the `Framework` enum, `AzureMLPipelineDataset` and `CliContext`.
- **12 pages kept `#methods`.** Every one renders **≥1** real method (1–3 each): `AzureMLPipelinesClient`, `ComputeConfig`, `PipelineFilterOptions`, `WorkspacesConfig`, `AzureMLAssetDataset`, `DistributedNodeConfig`, `AzureMLPipelineGenerator`, `AzureMLLocalRunHook`, `MlflowAzureMLHook`, `KedroContextManager`, `AzurePipelinesRunner`, `AzureMLScheduleClient`.
- 0 pages gained one.

Both directions matter: a guard that stripped *every* heading would also show 25 → fewer. It shows 12 retained, each with real methods.

### 4. `_dedupe_heading_ids` + ungated `_strip_redundant_section_titles`

| | before | after |
|---|---|---|
| pages with duplicate heading ids | 0 | **0** |
| leftover **mapped** `doc-section-title` spans | 0 | **0** |

`_dedupe_heading_ids` is **inert in this repo**, and that is expected: no docs page carries more than one `:::` directive, so no page renders two objects at the same depth. Stated as inert rather than as a pass — the duplicate-id checker was falsified by injecting a duplicate id into a built page, which correctly moved the count 0 → 1.

One `doc-section-title` span survives, on `hooks.MlflowAzureMLHook`, reading `Lifecycle`. **This is correct, not a leftover.** The strip is deliberately narrow — it removes only the five titles the dispatcher maps to real headings (`Parameters`, `Attributes`, `Returns`, `Raises`, `Examples`). `Lifecycle` is unmapped, gets no heading of its own, and its title is therefore its only label; stripping it would delete the label. Zero *mapped* titles survive anywhere.

### 5. `h5.doc-section-heading` matched nothing — fixed

The class sits on an inner span, so the old selector matched no element and Material's default `text-transform: uppercase; font-size: .8em` reasserted on every section heading, silently, with a green build.

Counted in the built HTML:

| shape | count |
|---|---|
| class **on** an `h5` | **0** |
| class in an inner span **under** an `h5` | **61** |
| class in an inner span under an `h3` | 115 |

So the old selector matched **0 of 61**. The shipped rule is now `h5.doc-section-heading, h5 .doc-section-heading` — the descendant arm matches all 61, and keeping both arms means it does not depend on where the class lands.

## Anchor parity

Anchors are URLs and this release changes the markup around every one, but `--strict` does not validate same-page fragments. Every heading `id` on all 80 content pages was recorded with its **level and document position**, before and after, and diffed as `(page, id, level, order)`.

| | result |
|---|---|
| total anchors | 566 → 553 |
| **anchor ids lost** | **13 — all of them `#methods`**, one per attributes-only class |
| anchor ids gained | **0** |
| **heading levels changed** | **0** |
| **heading order changed** | **0** |
| pages gaining/losing anchors entirely | **0** |

Every delta is accounted for: the drop is exactly fix 3, and nothing else moved. Against v0.27.3 the net is 554 → 553.

## Local content preserved

- **Nav 29 → 29 leaves**, parsed from YAML, order byte-identical. Home 1, Tutorials 3, How-to Guides 13, Explanation 6, Reference 6. Leaf-by-leaf: nothing lost, nothing gained. `mkdocs.yml` took **only** the 8-line `exclude_docs` addition — verified against the pristine `v0.28.0 → v0.28.1` render diff, which is that addition and nothing else.
- **`docstring_options.warn_unknown_params: false` survived** (parsed YAML). It is a local setting — absent from the pristine template render — and worth exactly 46 griffe warnings and a failing `--strict` if lost.
- `inventories` survived. Note it is the **template default** (`docs.python.org` only), not a local extension: the pristine v0.28.1 render carries the identical block, comment included.
- `max_python_version` still `3.13`; `troubleshoot.md` intact, no `troubleshooting.md` stub.
- **`git diff --stat -- docs/assets` is empty** — all 6 asset hashes byte-identical.
- **`.github/workflows/` is byte-identical** — `diff -r` against a pre-update copy of the whole directory reports no change across all 7 workflows.
- **No `.rej` files and no conflicts** in either round of this update.

## Verification

- `nox -s check_docs` — **exit 0, zero warnings**, zero griffe noise.
- **Index coverage: 24/24 sibling pages linked across all 4 indexes**, measured in **rendered** HTML. Reference 5/5, How-to 12/12, Explanation 5/5, Tutorials 2/2. A source-level check reported Reference as 0/5; that was the checker being blind to the `<!-- SUBPAGES -->` marker the hook expands, not a gap.
- **CSS/markup coupling confirmed in built HTML**, since a stale selector renders unstyled while the build stays green: 0 files still carry `source-code-details`.
- **See Also: 39 pages / 109 entries / 0 unlinked.**
- `docs/hooks.py`, `theme.css`, all 4 overrides and all 4 `material/overrides/*.html` are **byte-identical** to a fresh `copier copy --vcs-ref v0.28.1` — Tier 1 clean render, not a merge.
- **Full `prek run --all-files` clean** (14 hooks), including `fix end of files`, which is the hook v0.28.0 turned red. The `.rumdl_cache` was deleted and rumdl re-run cold, since a stale cache gives a false clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
