### PR TITLE
chore: update from template v0.28.4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: c3f6fcf8b6f2ce00e96ae5b918cff755cda0a545
+_commit: d6d0e8260d71339ffe46610d42b2ee4e5061ca93
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 git clone <repo-url>
 cd <project-dir>
 uv sync --group dev
-uv run prek install
+uv run prek install -f
 just test-fast
 ```
 

--- a/docs/pages/how-to/contribute.md
+++ b/docs/pages/how-to/contribute.md
@@ -27,7 +27,7 @@
 4. Install the git hooks (required):
 
     ```bash
-    uv run prek install
+    uv run prek install -f
     ```
 
 ## Make changes

--- a/justfile
+++ b/justfile
@@ -7,7 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    uv run prek install
+    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
+    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
+    # every commit. `-f` overwrites instead. Measured; the migration notice
+    # prek prints names this flag, and this is the command people actually run.
+    uv run prek install -f
 
 # Run tests and doctests with parallel execution
 test:


### PR DESCRIPTION
Updates the project from template `v0.28.3` to `v0.28.4`
(`d6d0e8260d71339ffe46610d42b2ee4e5061ca93`).

## What v0.28.4 changes

`uv run prek install` → `uv run prek install -f` in three places. Without `-f`,
prek finds a pre-v0.27.0 shim, moves it to `.git/hooks/pre-commit.legacy` and
**chains** it — both hooks then run on every commit. `-f` overwrites instead.
Since `just install` is the command people already run, the routine command
becomes self-healing.

No code, no config: `pyproject.toml`, `mkdocs.yml` and `.github/workflows/` are
all untouched.

| file | outcome |
|---|---|
| `justfile` | applied cleanly (+ the 4-line explanatory comment) |
| `CONTRIBUTING.md` | applied cleanly |
| `docs/pages/how-to/contribute.md` | **conflicted — resolved by hand, see below** |

## The conflict, and how it was resolved

This project's `contribute.md` is curated: 502 lines against the template's 580,
with its own H1 and section structure, and it indents the install block inside a
numbered list item. The template's hunk targets an *unindented* block, so it did
not apply.

**Copier left an inline conflict in the file — `UU` in `git status`, with
`<<<<<<<`/`>>>>>>>` markers — and produced no `.rej` at all.** A check that only
globbed for `.rej` would have called this clean. The injected block was the
template's pristine content, including headings this page deliberately does not
use (`Development Workflow`), so accepting it would have duplicated the setup
steps in two different structures.

Resolved the way the template's own guidance prescribes: restore the curated page
from `HEAD`, then hand-apply only what the template genuinely changed.

- Restored file verified **byte-identical** to the pre-update version.
- Then the single `-f` applied, giving a **one-line** whole-file diff.
- **502 lines preserved**; zero conflict markers remain (prek's
  `check for merge conflicts` hook independently agrees).

Verified in the **rendered** page rather than the source: `prek install -f`
appears once, no bare `prek install` remains, the curated H1 and `Make changes`
heading survive, and the pristine-only `Development Workflow` heading is absent.

## Verification

- All three files carry `-f`; a repo-wide `git grep` finds **no** remaining bare
  `prek install`.
- **Symbol set unchanged: 38 → 38** — 0 lost, 0 gained, 0 moved paths, 0 kind
  changes, 0 retargeted lookup keys — confirmed against both the v0.28.3 state
  and the original v0.28.1 baseline. The `distributed/` re-export layout is
  untouched, as expected since no discovery code moved.
- `docs/_api_pages.py` and `docs/hooks.py` byte-identical to pristine
  `copier copy --vcs-ref v0.28.4`.
- `nox -s check_docs`: **passes, 0 warnings**, 0 `could not be resolved`,
  38 API member pages.
- `git diff --stat -- docs/assets`: **empty**; all 6 asset hashes unchanged.
- `.github/workflows/`: **byte-identical**. `mkdocs.yml` and `pyproject.toml`:
  untouched.
- `docstring_options: {warn_unknown_params: false}` intact; nav still 29 leaves,
  identical leaf-by-leaf.
- Rendered: API table **38 rows**; See Also **44 sections / 114 entries /
  0 unlinked**; index coverage **0 gaps**.
- All prek hooks pass.

## One correction to the pre-dispatch measurement

The rollout brief recorded this repo's `justfile` as byte-matching pristine, with
no local drift to preserve. It does not — it carries **five** local
customisations:

```
test-slow:       ... || [ $? -eq 5 ]
test-docstrings: ... || [ $? -eq 5 ]
lint:            uv run --extra mlflow --locked ty check --exit-zero-on-warning src
build:           uv run --group docs python -m mkdocs build --clean
serve:           uv run --group docs python -m mkdocs serve -a localhost:8080
```

All five survived, because they sit far from the `install:` recipe the template
edited — so the outcome was right, but for a reason the brief did not have. Had
the change landed a few lines lower, the "no drift" assumption would have meant
nobody checked. Worth correcting in the fleet notes: the `--extra mlflow` on
`ty` and the `--group docs` on the mkdocs invocations are load-bearing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
