### PR TITLE
ci: add Versions passed roll-up to gate the version matrix

### DIFF
--- a/.github/workflows/tests-versions.yml
+++ b/.github/workflows/tests-versions.yml
@@ -60,3 +60,17 @@ jobs:
           nox -s "test_versions-${{ matrix.python-version }}(with_mlflow=${{ matrix.with_mlflow }}, azureml_spec='${{ matrix.azureml_spec }}', kedro_spec='${{ matrix.kedro_spec }}')"
         env:
           PYTEST_XDIST_AUTO_NUM_WORKERS: 0
+
+  versions-passed:
+    name: Versions passed
+    if: always()
+    needs: [versions]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if the version matrix did not pass
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::the version-compatibility matrix failed or was cancelled"
+          exit 1
+      - name: Version matrix passed
+        run: echo "All version-compatibility jobs passed or were legitimately skipped."


### PR DESCRIPTION
Adds a single stable required-check name (`Versions passed`) for the version-compat matrix, so the branch ruleset can gate it without listing brittle per-pin matrix names. Held for review — leave merge to the maintainer.