### PR TITLE
chore(template): sync to v0.36.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: e748f5c10c0fdd611bbbdae3783c130a82da87bd
+_commit: 804bc6947a8671392eb93470bb7fe0b8874722ee
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,8 +16,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    # Codecov upload authenticates via GitHub OIDC (tokenless) -- no stored CODECOV_TOKEN.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v7
 
@@ -44,9 +46,9 @@ jobs:
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v7
-        if: ${{ matrix.python-version == '3.12' && env.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.python-version == '3.12' }}
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
 
   create-issue-on-failure:
     needs: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,8 +104,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    # Codecov upload authenticates via GitHub OIDC (tokenless) -- no stored CODECOV_TOKEN.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -137,17 +139,17 @@ jobs:
         run: nox -s test --python ${{ matrix.python-version }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.python-version == '3.11' && env.CODECOV_TOKEN != '' }}
+        if: ${{ !cancelled() && matrix.python-version == '3.11' }}
         uses: codecov/test-results-action@v1
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
           file: '${{ github.workspace }}/junit.${{ matrix.python-version }}.xml'
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v7
-        if: ${{ matrix.python-version == '3.11' && env.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.python-version == '3.11' }}
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
           files: '${{ github.workspace }}/coverage.${{ matrix.python-version }}.xml'
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
Syncs the project to python-package-copier template **v0.36.0** (from v0.35.0, `_commit` e748f5c -> 804bc69).

## Delta

1. **Codecov -> tokenless GitHub OIDC** in `tests.yml` and `nightly.yml`: adds `permissions: id-token: write` (+ `contents: read`), the Codecov steps now use `use_oidc: true`, and the stored `CODECOV_TOKEN` env/`token:` inputs are dropped. Public repo, so OIDC works without a secret.
2. **`scorecard.yml`** already pinned to `@v2.4.4` locally (prior hotfix) -> reconciles cleanly, file unchanged.

## Verification

- `nox -s check_docs` (Python 3.11): build OK, **0 warnings** ("No issues found").
- `nox -s test_fast-3.11`: **409 passed**.
- `nox -s lint`: ruff / rumdl / ty all clean.
- prek (all files): all hooks pass.

## Preserved invariants

- `warn_unknown_params: false` (mkdocs.yml) intact — CI-critical.
- Bespoke `tests-versions.yml` untouched (copier does not own it).
- The 5 repo-only `src/` ARG ignores in `pyproject.toml` intact.
- Only 3 expected files changed: `.copier-answers.yml`, `tests.yml`, `nightly.yml`. No UU conflicts, no `.rej` files.
- `CODECOV_TOKEN` repo secret left untouched.

Held for review; do not merge.