### PR TITLE
chore: update from template v0.39.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 9bbf88ac3171f6296c91fcfdd3c3ef31ea6986f3
+_commit: 8cf89a1204392366a1a7dcfd7756647a389dde49
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,9 +65,14 @@ jobs:
       # Software bill of materials (CycloneDX) for the release, generated from the
       # locked dependency set so it enumerates exactly what this release resolves.
       - name: Generate SBOM (CycloneDX)
-        # renovate: datasource=pypi depName=cyclonedx-bom
         run: |
           uv export --frozen --no-emit-project --format requirements-txt -o sbom-requirements.txt
+          # The annotation must sit directly above the line carrying the version. The
+          # custom manager matches `depName=<x>` then scans forward within ONE line, so
+          # an annotation above `run: |` lands on that key and can never reach a version
+          # two lines below -- it parses as a comment, is silently read by nothing, and
+          # the pin rots at whatever it was set to.
+          # renovate: datasource=pypi depName=cyclonedx-bom
           uvx --from cyclonedx-bom==7.3.1 cyclonedx-py requirements sbom-requirements.txt \
             --output-format JSON --output-file sbom.cdx.json
 


### PR DESCRIPTION
Template v0.39.1. **Held for review — do not merge without checking the diff.**

A one-line follow-up to the v0.39.0 update: the `# renovate:` annotation on the SBOM step was placed where Renovate cannot read it.

## What was wrong

v0.39.0 pinned `cyclonedx-bom` and annotated it so the bot could bump it. The pin worked; the annotation did not:

```yaml
# renovate: datasource=pypi depName=cyclonedx-bom
run: |
  uv export ...
  uvx --from cyclonedx-bom==7.3.1 ...      # version 2 lines below -> never matched
```

The shared preset's manager scans forward from `depName=` within a **single line**. Placed above `run: |`, it lands on that key and can never reach the version. A full debug run over the fleet contains the word `cyclonedx` **zero times**, while `twine` — annotated directly above its version four lines away — appears eight times.

This diff moves the annotation inside the block, directly above the line carrying the version.

## Impact if you had not taken this

Narrow. The pin itself works, so releases keep using cyclonedx-bom 7.3.1 with the supported `--output-file` flag. What was lost is auto-bumping: when 7.x goes to 8.x, nothing would propose it and the pin would rot silently.

## Verification

```
copier update            exit 0
conflict-marker sweep    none
.rej sweep               none
changed files            exactly .copier-answers.yml + publish-release.yml
git diff docs/assets     empty
dead annotations         0  (was 1: publish-release.yml:cyclonedx-bom)
```

Every `# renovate:` annotation in this repo's workflows is now checked against the **preset's own regex**, not merely grepped for. That check is new in v0.39.1 and is what found this.

Measured across the fleet before the fix: 218 annotations, 210 readable, 8 dead — this one, in the template and in each of the seven repos.
