### PR TITLE
fix(ci): grant tests-versions what it uses, not what it asked for

### DIFF
--- a/.github/workflows/tests-versions.yml
+++ b/.github/workflows/tests-versions.yml
@@ -9,8 +9,11 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Running tests reads; nothing here touches a pull request. This previously granted
+# `pull-requests: write`, which no step used, and left `contents` at none -- checkout
+# worked only because the repository is public and clones unauthenticated.
 permissions:
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Found while fixing the `TokenPermissionsID` finding on kedro-dagster's copy of this workflow, during a fleet-wide security sweep.

`tests-versions.yml` declared:

```yaml
permissions:
  pull-requests: write
```

Nothing in the file touches a pull request — no `gh pr`, no `github-script`, no comment step. `pull-requests` is the only occurrence of the string in the workflow.

Declaring any `permissions` block also sets every unlisted scope to `none`, so `contents` was `none` and `actions/checkout` worked only because this repository is public and clones unauthenticated. Making it private would have broken CI.

Now `contents: read` — what it actually needs.