### PR TITLE
fix(ci): unblock PyPI publishing and split the nightly by interpreter

### DIFF
--- a/.claude/skills/polish-changelog/SKILL.md
+++ b/.claude/skills/polish-changelog/SKILL.md
@@ -56,7 +56,7 @@ gh pr list --state open --json number,headRefName,title \
 # or match the branch prefix:
 gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("changelog-v"))'
 gh pr checkout <number>
-```text
+```
 
 ### 2. Isolate the new section
 
@@ -74,7 +74,7 @@ For each bullet, get the real context from its linked PR (the subject line rarel
 
 ```bash
 gh pr view <N> --json title,body,files --jq '{title, body, files: [.files[].path]}'
-```text
+```
 
 Rewrite the description from that evidence, following the style contract below. **If the PR's title/body/diff does not support a clearer wording that is still accurate, keep the original subject unchanged.** A plausible-but-wrong rewrite reads clean and can claim behavior the code does not have — abstaining is the correct default under uncertainty. Never assert an effect you cannot see in the PR.
 
@@ -87,6 +87,7 @@ Each description is:
 - **No trailing period.**
 - **The user-visible effect over the internal mechanism**, when they differ.
 - **Self-contained** — no repo-internal codenames ("the fan-out"), no undefined invariants, nothing that needs `git log` to understand.
+- **Never provenance alone.** See the rule below.
 
 | Before (git-cliff, verbatim subject) | After |
 |---|---|
@@ -94,6 +95,26 @@ Each description is:
 | Correct three v0.29.0 rendering bugs the fan-out surfaced | Fix three docs-rendering regressions from v0.29.0 |
 | Drop the stale 'yohou documents pre-commit' claim | Remove an outdated note about pre-commit from the docs |
 | Render numpydoc References sections as a markdown list | *(already clear — leave unchanged)* |
+
+#### A description must name a change, never just a version
+
+`Update from template v0.39.0` is not a changelog entry. It names a *source* and a *version number* and says nothing about what the release did to this package — a reader learns strictly less than from the version header they are already looking at. The same failure wears other clothes: `Sync to v0.36.0`, `Bump the pinned toolchain`, `Apply the fan-out`, `Update dependencies`.
+
+**The rule:** the description says what landed *in this package*. Where the source matters for traceability, it goes at the end in parentheses as provenance — never as the subject.
+
+| Before | After |
+|---|---|
+| Update from template v0.39.0 | Fix three release-pipeline defects (template v0.39.0) |
+| Update from template v0.38.0 | Add a CLAUDE.md project-instructions file for AI assistants (template v0.38.0) |
+| Sync to v0.35.0 | Restrict workflow permissions and add secret scanning (template v0.35.0) |
+| Update from template v0.40.1 | Fix a shell injection in the release publish job (template v0.40.1) |
+
+Two traps this rule closes:
+
+- **Normalising toward the uninformative.** When several template-update bullets appear together it is tempting to give them one consistent phrasing — and the phrasing they already share is the empty one. Consistency is worth having in the *shape* (effect first, provenance in parens), never in the content.
+- **A parenthetical is not a description.** `Update from template v0.36.0 (Codecov OIDC + scorecard pin)` looks polished because it carries real information, but it still leads with the non-event. Promote the parenthetical to the subject and demote the version.
+
+If the linked PR genuinely does not say what changed for this package, that is a grounding failure, not a licence to write the version number: say what the diff shows (`Update pinned CI action digests`) and no more.
 
 ### 5. Self-verify, then deliver
 
@@ -108,7 +129,7 @@ Then commit and push to the PR branch — **do not merge**:
 ```bash
 git commit -am "chore(changelog): polish release notes for vX.Y.Z"
 git push
-```text
+```
 
 The maintainer reviews the polished diff on the PR and merges it.
 

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 10e9f41542bbcf96855ec8049cb1e0802572a610
+_commit: 7419e837c85f2cbc9df575297b3f9f6e7573dc89
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # A nightly exists to report, not to fail fast. Cancelling the other
+      # interpreters on the first failure turns one bad minute into a run that
+      # says nothing about the versions it never reached.
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     # Codecov upload authenticates via GitHub OIDC (tokenless) -- no stored CODECOV_TOKEN.
@@ -38,15 +42,28 @@ jobs:
         # renovate: datasource=pypi depName=nox
         run: uv tool install nox==2026.7.11
 
+      # `test_coverage` is pinned to the minimum Python, so `nox -s test_coverage`
+      # runs that interpreter whatever the matrix entry says. Asking for it on every
+      # entry ran the same suite once per version and exercised no other interpreter;
+      # the split mirrors the full/coverage split in tests.yml.
       - name: Run tests with coverage
+        if: matrix.python-version == '3.11'
         run: nox -s test_coverage
+
+      - name: Run tests
+        if: matrix.python-version != '3.11'
+        run: nox -s test --python ${{ matrix.python-version }}
 
       - name: Run docstring tests
         run: nox -s test_docstrings
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        if: ${{ matrix.python-version == '3.12' }}
+        # Gated on the entry that PRODUCES the report. This was a hardcoded '3.12'
+        # while `test_coverage` is pinned to the minimum Python, so it uploaded that
+        # run's coverage under a 3.12 label -- and in a project whose matrix has no
+        # 3.12 entry at all it uploaded nothing, silently and forever.
+        if: ${{ matrix.python-version == '3.11' }}
         with:
           use_oidc: true
           # Named explicitly, with the uploader's search off. This step had

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -184,7 +184,16 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        # Must stay recent enough for the twine it bundles to accept the core
+        # metadata version `hatchling` emits. v1.13.0 bundled twine < 7, which
+        # rejects `Metadata-Version: 2.5` with `InvalidDistribution` -- and since
+        # `[build-system] requires` leaves hatchling unpinned, every project broke
+        # here the day hatchling started emitting 2.5, with no change of its own.
+        # v1.14.2 moved to twine v7. Renovate keeps this current, but its updates
+        # are rate-limited: this one sat on the dependency dashboard for two weeks
+        # while noisier digest bumps took the weekly slots, so a release-blocking
+        # bump can be queued and invisible. Check the dashboard before releasing.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
           verify-metadata: false


### PR DESCRIPTION
**Held for review — do not merge.**

Template update v0.41.4 → v0.41.5. Four tracked files change; a fifth,
`.github/skills/polish-changelog/SKILL.md`, is written to disk but is gitignored
in this repo, so it does not appear in the diff.

## Why this matters

`pypa/gh-action-pypi-publish@v1.13.0` bundles twine < 7, which rejects the
`Metadata-Version: 2.5` that an unpinned `hatchling` now emits. This repo has no
release in flight, but it carried the broken pin, and its **next** release would
have failed at the publish step with `InvalidDistribution` and no change of its
own. The pin moves to **v1.14.2** (twine v7), still digest-pinned so Scorecard's
`PinnedDependenciesID` is unaffected:

```
uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
```

Note this is the one `uses:` line in the release that is *not* resolved toward
the local digest. The local digest `ed0c5393…` is v1.13.0, the broken version —
keeping it would have produced a green PR with the bug intact.

## `nightly.yml`

- `fail-fast: false` on the test matrix.
- The test step is split by interpreter. `nox -s test_coverage` is pinned to the
  minimum Python, so running it on every matrix entry ran the same 3.11 suite
  three times and exercised neither 3.12 nor 3.13. Non-minimum entries now run
  `nox -s test --python ${{ matrix.python-version }}`.
- The Codecov upload was gated on `matrix.python-version == '3.12'` while the
  report it uploads comes from the 3.11 entry, so this repo was publishing 3.11
  coverage under a 3.12 label. It is now gated on `'3.11'`.

`nightly.yml` has no `pull_request` trigger, so no check on this PR exercises it.
It was dispatched manually against this branch — see the comment below.

## `changelog.yml` — deliberately absent from the diff

The release bumps `actions/create-github-app-token` from `@v2` to `@v2.2.2`. This
repo is digest-pinned by Renovate at `fee1f7d6… # v2`, which is what it actually
runs, so the conflict resolves toward the local digest and the file ends
byte-identical to before. That is the correct outcome, not a missed update.

## Verification

- 3 inline conflicts (`UU`), zero `.rej`. All three were `uses:` lines; see above
  for how each was resolved.
- Whole-file diff of every touched file against the pre-update baseline: the only
  hunks are the template's intended ones.
- `git diff --stat -- docs/assets` — empty.
- `tests/conftest.py` byte-unchanged (sha256 `8f4e2654…`).
- `mkdocs.yml`, `.gitignore`, `noxfile.py`, `pyproject.toml`, `tests.yml`,
  `tests-versions.yml`, `codeql.yml`, `scorecard.yml`, `commit-message.yml`,
  `pr-title.yml` all byte-unchanged.
- `nightly.yml` job list and `needs:` graph unchanged (`test`, `release-smoke`,
  `create-issue-on-failure` ← needs `[test, release-smoke]`).
- All 13 `astral-sh/setup-uv` `version: "0.12.1"` sites intact; no reversion to
  the template's `"0.10.0"` seed.
- `docs_build/` byte-identical to a pristine v0.41.5 render.
