### PR TITLE
fix(cli): stop the execution path writing around the logging system

### DIFF
--- a/src/kedro_azureml_pipeline/cli/commands.py
+++ b/src/kedro_azureml_pipeline/cli/commands.py
@@ -471,7 +471,12 @@ def execute(
 
     with KedroContextManager(env=ctx.env, runtime_params=parameters) as mgr:
         runner = AzurePipelinesRunner(data_paths=data_paths)
-        mgr.session.run(pipeline, node_names=[node], runner=runner)
+        # `pipeline_names`, not positional: the first positional parameter of
+        # KedroSession.run is the deprecated `pipeline_name`, so passing it there
+        # logged a deprecation notice in every step of every job. It still works,
+        # which is the trap: nothing forces the fix until the parameter is removed
+        # and every cloud step fails at once.
+        mgr.session.run(pipeline_names=[pipeline], node_names=[node], runner=runner)
 
 
 @azureml_group.command("resolve-patterns")

--- a/src/kedro_azureml_pipeline/cli/functions.py
+++ b/src/kedro_azureml_pipeline/cli/functions.py
@@ -19,7 +19,7 @@ from kedro_azureml_pipeline.utils import CliContext
 if TYPE_CHECKING:
     from kedro_azureml_pipeline.config.models import ScheduleConfig
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def _read_mlflow_experiment_name(mgr: KedroContextManager) -> str | None:
@@ -55,7 +55,7 @@ def parse_runtime_params(params, silent=False):
     params : str
         JSON string of parameters, or falsy value.
     silent : bool
-        Suppress console output when ``True``.
+        Suppress the report when ``True``.
 
     Returns
     -------
@@ -65,7 +65,12 @@ def parse_runtime_params(params, silent=False):
     """
     if params and (parameters := json.loads(params.strip("'"))):
         if not silent:
-            click.echo(f"Running with extra parameters:\n{json.dumps(parameters, indent=4)}")
+            # Logged rather than echoed: this function is shared by the interactive
+            # submit path and by `execute`, which runs a node inside a step
+            # container. On stdout the block carried no timestamp, level or node
+            # identity, could not be levelled down, and was four unattributable
+            # lines per step in the consuming project's merged job log.
+            logger.info("Running with extra parameters:\n%s", json.dumps(parameters, indent=4))
     else:
         parameters = None
     return parameters

--- a/src/kedro_azureml_pipeline/distributed/utils.py
+++ b/src/kedro_azureml_pipeline/distributed/utils.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def is_distributed_master_node() -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -317,6 +317,43 @@ class TestExecute:
             )
             assert result.exit_code == 0
 
+    def test_execute_uses_the_supported_run_parameter(
+        self,
+        patched_kedro_package,
+        cli_context,
+        dummy_pipeline,
+        dummy_plugin_config,
+        tmp_path: Path,
+    ):
+        """`pipeline_name` is deprecated; passing it logged a notice in every step.
+
+        Asserted on the call rather than on the absence of a log line, so this
+        still means something once Kedro removes the parameter and stops warning.
+        """
+        patched_azure_runner = AzurePipelinesRunner(data_paths={})
+        create_kedro_conf_dirs(tmp_path)
+        with (
+            patch("kedro_azureml_pipeline.runner.AzurePipelinesRunner", new=patched_azure_runner),
+            patch.dict("kedro.framework.project.pipelines", {"__default__": dummy_pipeline}),
+            patch(
+                "kedro_azureml_pipeline.manager.KedroContextManager.plugin_config",
+                new_callable=mock.PropertyMock,
+                return_value=dummy_plugin_config,
+            ),
+            patch.object(Path, "cwd", return_value=tmp_path),
+            patch("kedro.framework.session.KedroSession.run") as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(
+                cli.execute,
+                ["--node", "node1", "--az-output", "i2", str(tmp_path)],
+                obj=cli_context,
+            )
+
+        assert mock_run.called, "the execute command did not run the session"
+        assert mock_run.call_args.args == (), "the pipeline was passed positionally, which is `pipeline_name`"
+        assert mock_run.call_args.kwargs["pipeline_names"] == ["__default__"]
+
 
 class TestRun:
     """Tests for the ``kedro azureml run`` CLI command."""

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -1,5 +1,6 @@
 """Tests for CLI helper functions."""
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -35,6 +36,48 @@ class TestParseRuntimeParams:
     def test_quoted_json(self):
         result = parse_runtime_params('\'{"key": "value"}\'', silent=True)
         assert result == {"key": "value"}
+
+    def test_the_report_is_a_log_record(self, caplog):
+        """This runs inside a step container as well as at a terminal.
+
+        Written straight to stdout the block carried no timestamp, level or node
+        identity, and was four unattributable lines per step in a consuming
+        project's merged job log. As a record it inherits whatever the
+        application configured, like every other line.
+        """
+        with caplog.at_level(logging.INFO, logger="kedro_azureml_pipeline.cli.functions"):
+            parse_runtime_params('{"arena_snapshot": "demo"}')
+
+        records = [r for r in caplog.records if "Running with extra parameters" in r.getMessage()]
+        assert records, "the parameter block did not go through logging"
+        assert records[0].name == "kedro_azureml_pipeline.cli.functions", (
+            "a record on the root logger cannot be levelled by package"
+        )
+
+    def test_an_operator_can_turn_the_report_down(self, caplog):
+        """The property stdout could never offer."""
+        with caplog.at_level(logging.WARNING, logger="kedro_azureml_pipeline.cli.functions"):
+            parse_runtime_params('{"arena_snapshot": "demo"}')
+
+        assert not [r for r in caplog.records if "Running with extra parameters" in r.getMessage()]
+
+    def test_the_block_is_not_echoed_anywhere(self):
+        """Structural: nothing may reintroduce the raw write."""
+        source = Path("src/kedro_azureml_pipeline/cli/functions.py").read_text()
+        assert 'click.echo(f"Running with extra parameters' not in source
+
+    def test_the_report_still_names_the_parameters(self, caplog):
+        with caplog.at_level(logging.INFO, logger="kedro_azureml_pipeline.cli.functions"):
+            parse_runtime_params('{"arena_snapshot": "demo"}')
+
+        assert "arena_snapshot" in caplog.records[0].getMessage()
+
+    def test_silent_reports_nothing(self, caplog, capsys):
+        with caplog.at_level(logging.INFO, logger="kedro_azureml_pipeline.cli.functions"):
+            parse_runtime_params('{"a": 1}', silent=True)
+
+        assert capsys.readouterr().out == ""
+        assert caplog.records == []
 
 
 class TestParseExtraEnvParams:


### PR DESCRIPTION
## Description

Two defects on the node-execution path, both found while making a consuming project's Azure ML logs readable, and both visible in every step of every job.

**The parameter block was written with `click.echo`.** `parse_runtime_params` is shared by the interactive submit path and by `execute`, which runs a node inside a step container. On a real arena job that was four lines per step on raw stdout: no timestamp, no level, no node identity, no way for an operator to turn it down, and unattributable once a job's step logs are merged and sorted by time. It is now a log record like everything else.

**Two modules logged to the root logger**, so their records were named `root` and could not be levelled by package. Fixing the first defect without this one would have satisfied its letter and not its point, so both now use `getLogger(__name__)`, matching the rest of the package.

**`execute` passed the pipeline positionally to `KedroSession.run`**, whose first positional parameter is the deprecated `pipeline_name`, so every step logged a deprecation notice. It still works, which is the trap: nothing forces the fix until the parameter is removed and every cloud step fails at once.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Measured on a real Azure ML arena job: of 543 lines merged across six steps, about 64 bypassed logging entirely and therefore carried no timestamp or identity. Roughly half of those were this plugin's parameter block. That defeats the property the consuming project's logging work exists to create, which is that a job's step logs concatenate and sort into one attributable stream.

The deprecation notice is one line per step today and a hard failure whenever Kedro removes the parameter.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

The deprecation test asserts on the call rather than on the absence of a log line, so it still means something once Kedro stops warning.

No documentation change: none of this is user-facing configuration. The behaviour change is that two lines an operator used to see on stdout are now log records at INFO, which an application's existing logging configuration already governs.

Tests: 422 passing. `just lint` clean (ruff, rumdl, ty).
