### PR TITLE
docs(citation): tell users how to cite Kedro AzureML Pipeline

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -73,9 +73,18 @@ docs/stylesheets/theme.css
 .github/PULL_REQUEST_TEMPLATE.md
 SECURITY.md
 .claude/skills/**                   # Skill files managed by template (the tracked copy)
-.github/skills/**                   # Byte-identical Copilot mirror; gitignored, so an
-                                    # update never delivers it -- copier works through
-                                    # git and skips ignored paths. Edit .claude/skills.
+.github/skills/**                   # Byte-identical Copilot mirror. Gitignored, so an
+                                    # update writes it to disk UNTRACKED: the change is
+                                    # delivered, and no one reviews it because it never
+                                    # reaches a diff. Measured on the v0.43.0 fan-out,
+                                    # where copier updated this very file in all seven
+                                    # repos while `git status` stayed silent.
+                                    #
+                                    # This entry used to say copier "skips ignored
+                                    # paths" and that an update "never delivers it".
+                                    # Both halves are wrong. Do not rely on either:
+                                    # if you need to know what landed here, look at
+                                    # the file on disk, not at git. Edit .claude/skills.
 ```
 
 ---

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,12 +1,12 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 80b92b27698c3755d6d432d34ce2dca65bcab19e
+_commit: b6e06378b2e2967808bfb55f68f0affad0fcca28
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin
 code_owner: '@gtauzin'
-description: Kedro plugin with Azure ML Pipelines support
+description: Orchestrate Kedro pipelines with Azure ML Pipeline
 github_username: stateful-y
 include_actions: True
 include_codecov: True

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,8 +23,9 @@ build:
     # on sys.path (via the wheel's `dev-mode-dirs`) so the build loads the
     # `docs_build` markdown extensions by module name. `uv run` uses that venv.
     - asdf plugin add uv || true
-    - asdf install uv latest
-    - asdf global uv latest
+    # renovate: datasource=github-releases depName=astral-sh/uv
+    - asdf install uv 0.10.0
+    - asdf global uv 0.10.0
     - uv sync --group docs
     # Generate the API pages and export the notebooks -- the explicit step that
     # replaced the deleted on_pre_build hook.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,12 @@
 # docs/pages/reference/citation.md. All three render from the same answers.
 cff-version: 1.2.0
 message: "If you use Kedro AzureML Pipeline in your work, please cite it as below."
-title: "Kedro AzureML Pipeline"
-abstract: "Kedro plugin with Azure ML Pipelines support"
+# Name and description in one field, because that is what a citation renders. A
+# reference list shows the title and nothing else, so a bare package name tells a
+# reader who has not met the project what it was called and not what it is. There
+# is deliberately no separate `abstract`: it duplicated this text, and the field a
+# citation actually prints is this one.
+title: "Kedro AzureML Pipeline: Orchestrate Kedro pipelines with Azure ML Pipeline"
 type: software
 authors:
   # Recorded as a single `name`, which the format treats as an entity rather than a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Kedro AzureML Pipeline
 
-Kedro plugin with Azure ML Pipelines support
+Orchestrate Kedro pipelines with Azure ML Pipeline
 
 Instructions for AI coding assistants working in this repository.
 

--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ This project is licensed under the terms of the [Apache-2.0 License](https://git
 
 If you use Kedro AzureML Pipeline in work you publish, please cite it:
 
-Guillaume Tauzin. Kedro AzureML Pipeline. https://github.com/stateful-y/kedro-azureml-pipeline
+Guillaume Tauzin. Kedro AzureML Pipeline: Orchestrate Kedro pipelines with Azure ML Pipeline. https://github.com/stateful-y/kedro-azureml-pipeline
 
 Or in BibTeX:
 
 ```bibtex
 @software{kedro_azureml_pipeline,
   author  = "Guillaume Tauzin",
-  title   = "{Kedro AzureML Pipeline}",
+  title   = "{Kedro AzureML Pipeline: Orchestrate Kedro pipelines with Azure ML Pipeline}",
   url     = "https://github.com/stateful-y/kedro-azureml-pipeline",
   license = "Apache-2.0"
 }

--- a/docs/pages/reference/citation.md
+++ b/docs/pages/reference/citation.md
@@ -8,14 +8,14 @@ If you use Kedro AzureML Pipeline in work you publish, please cite it.
 
 ## Plain text
 
-Guillaume Tauzin. Kedro AzureML Pipeline. https://github.com/stateful-y/kedro-azureml-pipeline
+Guillaume Tauzin. Kedro AzureML Pipeline: Orchestrate Kedro pipelines with Azure ML Pipeline. https://github.com/stateful-y/kedro-azureml-pipeline
 
 ## BibTeX
 
 ```bibtex
 @software{kedro_azureml_pipeline,
   author  = "Guillaume Tauzin",
-  title   = "{Kedro AzureML Pipeline}",
+  title   = "{Kedro AzureML Pipeline: Orchestrate Kedro pipelines with Azure ML Pipeline}",
   url     = "https://github.com/stateful-y/kedro-azureml-pipeline",
   license = "Apache-2.0"
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Kedro AzureML Pipeline
-site_description: Kedro plugin with Azure ML Pipelines support
+site_description: Orchestrate Kedro pipelines with Azure ML Pipeline
 site_url: https://kedro-azureml-pipeline.readthedocs.io/
 # The built site is throwaway output, so it goes under `.artifacts/` with the
 # caches and coverage reports instead of dropping a `site/` at the repo root.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "kedro_azureml_pipeline"
 dynamic = ["version"]
-description = "Kedro plugin with Azure ML Pipelines support"
+description = "Orchestrate Kedro pipelines with Azure ML Pipeline"
 readme = "README.md"
 maintainers = [
     { name = "Guillaume Tauzin", email = "gtauzin@stateful-y.io" }


### PR DESCRIPTION
## Description

Template update, v0.42.0 to v0.43.1. Adds citation metadata so this project can be cited:

- **`CITATION.cff`** at the repo root, which GitHub's "Cite this repository" button, Zenodo and most reference managers read.
- **A `## How do I cite ...?` section in `README.md`**, between License and Acknowledgements.
- **`docs/pages/reference/citation.md`**, in the Reference nav beside Changelog and API.

The citation title is `<name>: <description>`, because a reference list prints the title and nothing else. There is no `abstract`: it held the same text in a field no citation renders.

`CITATION.cff` deliberately carries no `version` and no `date-released` (both optional, both wrong the day after the next release with nothing keeping them right), and its `doi:` line is commented out because no release has been deposited.

Also pins the uv version Read the Docs installs rather than resolving `latest` at build time.

## Verification

- Conflicts checked three ways: `.rej` files, `U` states in porcelain, and a conflict-marker grep.
- Nav counted **per section** and compared leaf-by-leaf including titles. This release touches no nav line, so any change at all would be a clobber.
- `CITATION.cff` verified on disk and not gitignored, with its title, repository URL and description confirmed to be this project's own.
- `git diff --stat -- docs/assets` empty.
- The project's own hooks (`prek run --all-files`) run after staging, so the new files are actually seen.

**Held for review. Do not merge without reading the diff.**

## Description change

This PR also changes the project description to **"Orchestrate Kedro pipelines with Azure ML Pipeline"**, applied to the copier answer, `pyproject.toml` (so PyPI), `mkdocs.yml`'s `site_description`, `CLAUDE.md`, and every citation surface.

Note the GitHub "About" field still reads "Kedro plugin to support running pipelines on Microsoft Azure ML Pipeline". That is set in repository settings, not in any file, so it is not changed here.
