### PR TITLE
ci(automerge): drain the dependency queue one PR at a time

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -119,6 +119,12 @@ CITATION.cff                       # renders entirely from copier answers, which
                                    # `automerge` label, or the workflow starts approving
                                    # updates nothing chose to automate. A project may add
                                    # its own steps, so merge rather than overwrite.
+.github/workflows/drain-automerge-queue.yml  # conditional: include_actions. Advances one
+                                   # automerge PR per push to the default branch. The
+                                   # App-token step is load-bearing, not boilerplate: a
+                                   # branch updated with GITHUB_TOKEN triggers no checks,
+                                   # so the PR would stall with its required checks never
+                                   # reported. Do not "simplify" it to GITHUB_TOKEN.
 .github/workflows/publish-release.yml  # conditional: include_actions
 .github/workflows/nightly.yml      # conditional: include_actions
 .github/workflows/changelog.yml    # conditional: include_actions

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: b6e06378b2e2967808bfb55f68f0affad0fcca28
+_commit: d1a6ab905ab9ff851af3db8faca1ec244275a09f
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/drain-automerge-queue.yml
+++ b/.github/workflows/drain-automerge-queue.yml
@@ -1,0 +1,99 @@
+name: Drain Automerge Queue
+
+# A branch protection rule that requires branches to be up to date deadlocks
+# unattended dependency updates. GitHub's auto-merge refuses to merge a PR whose
+# branch is behind its base, and it does NOT update the branch itself. Renovate does
+# rebase stale branches, but only when it next runs, and the moment one PR merges every
+# other open branch is behind again. The result is roughly one merge per run: the queue
+# never drains, while every PR in it looks approved, green and ready.
+#
+# This workflow closes that gap. On every push to the default branch it advances exactly
+# ONE pull request: the oldest automerge-labelled bot PR that is behind. Updating the
+# branch reruns its checks, auto-merge then lands it, and that merge pushes the default
+# branch again, which runs this workflow for the next one. The queue drains itself, one
+# CI run per merge, with no schedule and nothing to maintain.
+#
+# It does nothing at all when no PR is waiting, and it stops on its own once the queue is
+# empty, so there is no loop to break.
+
+on:
+  push:
+    branches: [main]
+
+# Least-privilege default. This job needs no GITHUB_TOKEN scopes at all, because every
+# API call is made with the App token minted below.
+permissions: {}
+
+# One at a time. Several merges landing together would otherwise each pick a PR, and a
+# burst of branch updates is the CI storm this design exists to avoid.
+concurrency:
+  group: drain-automerge-queue
+  cancel-in-progress: false
+
+jobs:
+  advance-one:
+    name: Advance the automerge queue
+    runs-on: ubuntu-latest
+    steps:
+      # The App token is not decoration. A branch updated with the default GITHUB_TOKEN
+      # does NOT trigger a new workflow run: GitHub suppresses that to prevent recursion.
+      # The updated head commit would therefore carry none of the required checks, they
+      # would sit "Expected -- waiting for status to be reported" forever, and auto-merge
+      # would never fire. The PR would look freshly updated and be more stuck than before.
+      # An App token is a different identity, so its push does trigger the checks.
+      - name: Generate a token from the fleet automation GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v2.2.2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Update the oldest automerge PR that is behind
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Oldest first, so the queue is FIFO and a PR cannot be starved by newer ones.
+          # The same three conditions as renovate-automerge.yml, for the same reasons:
+          # a Bot author, a `renovate/` branch, and the `automerge` label that the
+          # Renovate config applies only to rules it also marks `automerge: true`.
+          candidates=$(gh api \
+            "repos/$REPO/pulls?state=open&sort=created&direction=asc&per_page=100" \
+            --jq '.[]
+                  | select(.user.type == "Bot")
+                  | select(.head.ref | startswith("renovate/"))
+                  | select([.labels[].name] | index("automerge"))
+                  | .number')
+
+          if [ -z "$candidates" ]; then
+            echo "No automerge-labelled bot pull requests are open. Nothing to do."
+            exit 0
+          fi
+
+          for number in $candidates; do
+            # `mergeable_state` is computed lazily: the first read can legitimately
+            # return "unknown" and resolve on a retry. Treating that as "not behind"
+            # would skip a PR that is in fact waiting, so ask again before giving up.
+            state=""
+            for _ in 1 2 3; do
+              state=$(gh api "repos/$REPO/pulls/$number" --jq '.mergeable_state')
+              [ "$state" != "unknown" ] && break
+              sleep 5
+            done
+
+            echo "PR #${number}: mergeable_state=${state}"
+
+            if [ "$state" = "behind" ]; then
+              echo "Updating #${number} so its checks rerun against the current base."
+              gh api -X PUT "repos/$REPO/pulls/${number}/update-branch"
+              echo "Done. Auto-merge lands it once the required checks pass, and that"
+              echo "merge triggers this workflow again for the next one."
+              exit 0
+            fi
+          done
+
+          # Everything else is already current, or blocked on its own checks, or has a
+          # real conflict. None of those is something a branch update can fix.
+          echo "No automerge pull request is behind its base. Nothing to advance."


### PR DESCRIPTION
**Held for review, do not merge.**

Template update from `python-package-copier` **v0.43.1 → v0.44.0** (`b6e0637` → `d1a6ab9`).

## What lands

`.github/workflows/drain-automerge-queue.yml` (new, 99 lines).

The org ruleset sets `strict_required_status_checks_policy: true`. GitHub's auto-merge
refuses to merge a branch that is behind its base and does **not** update the branch
itself; Renovate rebases only on its next run, and a single merge puts every other open
branch behind again. The result is approved, green, automerge-labelled dependency PRs
that never land.

The new workflow advances exactly **one** pull request per push to `main`: the oldest
automerge-labelled bot PR whose `mergeable_state` is `behind`. Updating that branch
reruns its checks, auto-merge lands it, and that merge pushes `main`, which runs the
workflow again. The queue drains itself at one CI run per merge, with no schedule.

It uses the fleet automation GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`, already used
by `changelog.yml` in this repo) rather than `GITHUB_TOKEN` on purpose: a branch updated
with `GITHUB_TOKEN` triggers no workflow run, so the updated head would carry none of the
required checks and the PR would deadlock while looking freshly updated.

## Everything else

| file | change |
|---|---|
| `.claude/skills/update-from-template/references/file-classification.md` | +6, tier entry for the new workflow |
| `.copier-answers.yml` | `_commit` bump |
| `.github/workflows/{changelog,commit-message,nightly,publish-release,tests}.yml` | **no change** |

The five templated workflows carry a uv seed bump upstream (`0.10.0` → `0.12.3`). Renovate
had already moved this repo to `0.12.3`, so base and both sides agree and the files come
out byte-identical. All **13** `version: "0.12.3"` sites are unchanged and no `"0.10.0"`
remains anywhere. That is the correct outcome, not a failed update.

## Verification

- `copier update` exit 0. **No `.rej` files, no `U` states, no conflict markers**
  (sweep falsified against an injected 3-marker instance on a scratch copy).
- Whole-tree `sha256sum` over every tracked file, pre vs post: **exactly two tracked files
  differ**, both listed above. Nothing else in the repo moved.
- `git diff --stat -- docs/assets` is **empty**.
- `mkdocs.yml` nav unchanged: 32 leaves, Home 1 / Tutorials 3 / How-to 14 / Explanation 7 /
  Reference 7, `Reference` last.
- The delivered `drain-automerge-queue.yml` and `file-classification.md` are byte-identical
  to a pristine `copier copy --vcs-ref v0.44.0` at this repo's own answers.
- Action digest pins: **49 before, 49 after**. The one tag pin is the new file's
  `actions/create-github-app-token@v2.2.2`, left for Renovate to digest-pin.
- `uv run prek run --all-files`: 13 hooks, all passed.
- The gitignored `.github/skills/` twin was written to disk untracked and left there,
  as intended.

`drain-automerge-queue.yml` triggers on `push` to `main` only, so **nothing on this PR
exercises it**. Its first real run will be this PR's own merge. Verified statically.
