### PR TITLE
feat(generator): name the signal when a step command dies of one

### DIFF
--- a/src/kedro_azureml_pipeline/generator.py
+++ b/src/kedro_azureml_pipeline/generator.py
@@ -40,6 +40,18 @@ from kedro_azureml_pipeline.distributed.config import Framework
 
 logger = logging.getLogger(__name__)
 
+#: Appended to every step command. Azure ML surfaces a signal death as a bare
+#: nonzero exit, so the one fact that matters for diagnosis, which signal, never
+#: reaches the failure page. It has to be classified in the shell: nothing inside
+#: the Python process survives a SIGSEGV or SIGKILL to report it.
+EXIT_CLASSIFICATION_SUFFIX = (
+    '; rc=$?; if [ "$rc" -gt 128 ]; then '
+    'echo "kedro azureml execute: killed by signal $((rc-128)) (SIG$(kill -l $((rc-128)))). '
+    "A signal death is a native crash or an external kill (out-of-memory, preemption); "
+    'the Python-level traceback, if any, is in user_logs/std_log_process_*.txt" >&2; '
+    "fi; exit $rc"
+)
+
 
 class ConfigException(BaseException):
     """Raised when pipeline generator configuration is invalid.
@@ -606,7 +618,9 @@ class AzureMLPipelineGenerator:
         Returns
         -------
         str
-            Full shell command for ``kedro azureml execute``.
+            Full shell command for ``kedro azureml execute``, ending with the
+            exit-classification suffix that names the signal when the process
+            dies of one.
         """
         input_data_paths = (
             [
@@ -631,4 +645,4 @@ class AzureMLPipelineGenerator:
             + f"kedro azureml -e {self.kedro_environment} execute --pipeline={self.pipeline_name} --node={node.name} "  # noqa
             + " ".join(input_data_paths + output_data_paths)
             + (f" --params='{self.params}'" if self.params else "")
-        ).strip()
+        ).strip() + EXIT_CLASSIFICATION_SUFFIX

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,3 +1,4 @@
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +13,11 @@ from kedro_azureml_pipeline.constants import (
     KEDRO_AZUREML_MLFLOW_NODE_NAME,
     KEDRO_AZUREML_MLFLOW_RUN_NAME,
 )
-from kedro_azureml_pipeline.generator import AzureMLPipelineGenerator, ConfigException
+from kedro_azureml_pipeline.generator import (
+    EXIT_CLASSIFICATION_SUFFIX,
+    AzureMLPipelineGenerator,
+    ConfigException,
+)
 
 
 class TestPipelineGeneration:
@@ -82,6 +87,63 @@ class TestPipelineGeneration:
                 assert az_pipeline.jobs[node.name].component.is_deterministic == ("deterministic" in node.tags), (
                     "is_deterministic property does not match node tag"
                 )
+
+
+class TestExitClassification:
+    """A step that dies of a signal names it in stderr instead of a bare exit code.
+
+    Azure ML reports a signal death as a nonzero exit with no signal name, so the
+    failure page cannot distinguish a native crash from an ordinary exception.
+    The classification runs in the shell because nothing inside the Python
+    process survives a SIGSEGV or SIGKILL to report it.
+    """
+
+    def test_every_command_carries_the_suffix(self, dummy_pipeline, dummy_plugin_config, multi_catalog):
+        with patch.object(AzureMLPipelineGenerator, "get_kedro_pipeline", return_value=dummy_pipeline):
+            generator = AzureMLPipelineGenerator(
+                "dummy_pipeline",
+                "unit_test_env",
+                dummy_plugin_config,
+                {},
+                catalog=multi_catalog,
+                aml_env="unit_test/aml_env@latest",
+            )
+            az_pipeline = generator.generate()
+
+        for job in az_pipeline.jobs.values():
+            assert job.command.endswith(EXIT_CLASSIFICATION_SUFFIX)
+
+    def test_a_segfault_is_named_in_stderr(self):
+        proc = subprocess.run(
+            ["bash", "-c", "sh -c 'kill -SEGV $$'" + EXIT_CLASSIFICATION_SUFFIX],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 128 + 11
+        assert "killed by signal 11 (SIGSEGV)" in proc.stderr
+
+    def test_a_clean_exit_adds_nothing(self):
+        proc = subprocess.run(
+            ["bash", "-c", "true" + EXIT_CLASSIFICATION_SUFFIX],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0
+        assert proc.stderr == ""
+
+    def test_an_ordinary_failure_keeps_its_code_unclassified(self):
+        """A Python exception exits with a small code and its own traceback; the
+        suffix must neither relabel it nor swallow the code."""
+        proc = subprocess.run(
+            ["bash", "-c", "sh -c 'exit 3'" + EXIT_CLASSIFICATION_SUFFIX],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 3
+        assert proc.stderr == ""
 
 
 class TestComputeResources:


### PR DESCRIPTION
## Description

Append a shell suffix to every generated step command that classifies exit codes above 128 and writes the signal's number and name to stderr, e.g. `killed by signal 11 (SIGSEGV)`. Clean exits and ordinary nonzero exits are untouched, and the original exit code is preserved in every case.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Azure ML surfaces a signal death as a bare nonzero exit ("Process with rank 0 exited with code -2"), so the failure page cannot distinguish a native crash from an ordinary Python exception. This surfaced while diagnosing a SIGSEGV inside concurrent CatBoost fits: the diagnosis required downloading logs and reading a faulthandler dump. The classification has to run in the shell because nothing inside the Python process survives a SIGSEGV or SIGKILL to report it.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

The suffix is exercised for real in tests by running it under bash against a segfaulting process, a clean exit, and an ordinary failure. `tests/test_cli.py::TestExecute::test_invoke_execute` fails on clean main as well and is unrelated.