### PR TITLE
feat(config): let compute entries select a Kubernetes instance type

### DIFF
--- a/docs/pages/reference/configuration.md
+++ b/docs/pages/reference/configuration.md
@@ -58,23 +58,34 @@ Each compute entry (`ClusterConfig`) has the following fields:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `cluster_name` | string | yes | Name of the Azure ML compute cluster |
+| `cluster_name` | string | on `__default__` | Name of the Azure ML compute cluster. Tag entries inherit it from `__default__` when omitted |
+| `instance_type` | string | no | Azure ML instance type to run steps under. Kubernetes compute targets only |
 
 Jobs reference a compute entry by name via their `compute` field.
 
+### Kubernetes compute targets
+
+When `cluster_name` points at an attached Kubernetes compute target (AKS or Azure Arc), `instance_type` selects the `InstanceType` custom resource the step runs under. Instance types are defined on the cluster by its administrator; the plugin passes the name through without validating it.
+
+When `instance_type` is omitted, Azure ML runs the step under `defaultinstancetype`, whose stock definition limits each step to 2 CPU cores, 2 GiB of memory, and no GPU. Set an instance type for any workload that needs more than that ceiling, and for every GPU workload.
+
+The field has no effect on AmlCompute clusters; Azure ML ignores it there.
+
 ### Tag-based routing
 
-Kedro node tags can route nodes to specific compute clusters. When a node has a tag that matches a named compute entry, that entry is merged with `__default__`:
+Kedro node tags can route nodes to specific compute clusters. When a node has a tag that matches a named compute entry, that entry is merged with `__default__` field by field:
 
 ```yaml
 compute:
   __default__:
-    cluster_name: "cpu-cluster"
+    cluster_name: "k8s-compute"
   gpu:
-    cluster_name: "gpu-cluster"
+    instance_type: "gpu-large"
+  cpu-heavy:
+    cluster_name: "other-compute"
 ```
 
-A node tagged `gpu` in your Kedro pipeline will run on `gpu-cluster`. Nodes without a matching tag fall back to `__default__`. Fields from the tagged entry override `__default__` fields.
+A node tagged `gpu` in your Kedro pipeline will run on `k8s-compute` under the `gpu-large` instance type. Nodes without a matching tag fall back to `__default__`. Fields from the tagged entry override `__default__` fields, and omitted fields are inherited: the `cpu-heavy` entry above inherits any `instance_type` set on `__default__`, so set it explicitly when the target cluster defines different instance types.
 
 ---
 

--- a/src/kedro_azureml_pipeline/config/models.py
+++ b/src/kedro_azureml_pipeline/config/models.py
@@ -92,8 +92,29 @@ class ClusterConfig(BaseModel):
 
     Parameters
     ----------
-    cluster_name : str
-        Name of the Azure ML compute cluster.
+    cluster_name : str or None
+        Name of the Azure ML compute cluster. Required on the
+        ``__default__`` entry. A tag entry that omits it inherits the
+        ``__default__`` cluster during resolution.
+    instance_type : str or None
+        Name of the Azure ML instance type to run steps under. Only
+        meaningful when ``cluster_name`` is an attached Kubernetes
+        compute target, where instance types are ``InstanceType``
+        custom resources defined on the cluster. When omitted, Azure ML
+        runs steps under ``defaultinstancetype``, whose stock definition
+        limits each step to 2 CPU cores, 2 GiB of memory, and no GPU.
+        AmlCompute clusters ignore this field.
+
+    Examples
+    --------
+    ```yaml
+    compute:
+      __default__:
+        cluster_name: "k8s-compute"
+      gpu-nodes:
+        cluster_name: "k8s-compute"
+        instance_type: "gpu-large"
+    ```
 
     See Also
     --------
@@ -102,7 +123,14 @@ class ClusterConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    cluster_name: str = Field(description="Name of the Azure ML compute cluster.")
+    cluster_name: str | None = Field(
+        default=None,
+        description="Name of the Azure ML compute cluster. Required on '__default__'; tag entries inherit it when omitted.",
+    )
+    instance_type: str | None = Field(
+        default=None,
+        description="Azure ML instance type for Kubernetes compute targets. None means the cluster's defaultinstancetype.",
+    )
 
 
 class ComputeConfig(RootModel[dict[str, ClusterConfig]]):
@@ -129,10 +157,13 @@ class ComputeConfig(RootModel[dict[str, ClusterConfig]]):
         Raises
         ------
         ValueError
-            If the ``__default__`` key is missing.
+            If the ``__default__`` key is missing, or if it does not
+            set ``cluster_name``.
         """
         if "__default__" not in self.root:
             raise ValueError("ComputeConfig must contain a '__default__' key")
+        if self.root["__default__"].cluster_name is None:
+            raise ValueError("The '__default__' compute entry must set cluster_name")
         return self
 
     def resolve(self, tag: str | None = None) -> ClusterConfig:
@@ -545,6 +576,8 @@ compute:
     cluster_name: "<cluster_name>"
   # gpu-nodes:
   #   cluster_name: "<gpu_cluster_name>"
+  #   # Kubernetes compute only: instance type to run steps under
+  #   # instance_type: "<instance_type_name>"
 
 execution:
   # Azure ML Environment to use during pipeline execution

--- a/src/kedro_azureml_pipeline/generator.py
+++ b/src/kedro_azureml_pipeline/generator.py
@@ -465,6 +465,8 @@ class AzureMLPipelineGenerator:
         command_kwargs = {}
         command_kwargs.update(self._get_distributed_azure_command_kwargs(node))
 
+        target_resource = self.get_target_resource_from_node_tags(node)
+
         mlflow_env_vars = {}
         if self.experiment_name is not None:
             mlflow_env_vars[KEDRO_AZUREML_MLFLOW_ENABLED] = "1"
@@ -478,7 +480,8 @@ class AzureMLPipelineGenerator:
             name=self._sanitize_azure_name(node.name),
             display_name=node.name,
             command=self._prepare_command(node, pipeline),
-            compute=self.get_target_resource_from_node_tags(node).cluster_name,
+            compute=target_resource.cluster_name,
+            instance_type=target_resource.instance_type,
             environment_variables={
                 "KEDRO_ENV": self.kedro_environment,
                 **mlflow_env_vars,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,12 +65,32 @@ class TestWorkspacesConfig:
             ws.resolve("missing")
 
 
+class TestClusterConfig:
+    """Single compute entry fields."""
+
+    def test_instance_type_defaults_to_none(self):
+        cluster = ClusterConfig(cluster_name="cpu")
+        assert cluster.instance_type is None
+
+    def test_instance_type_loads(self):
+        cluster = ClusterConfig(cluster_name="k8s-compute", instance_type="gpu-large")
+        assert cluster.instance_type == "gpu-large"
+
+    def test_unknown_key_is_rejected_by_name(self):
+        with pytest.raises(ValidationError, match="node_selector"):
+            ClusterConfig(cluster_name="cpu", node_selector="gpu=true")
+
+
 class TestComputeConfig:
     """Keyed compute lookup with ``__default__`` enforcement."""
 
     def test_requires_default_key(self):
         with pytest.raises(ValueError, match="__default__"):
             ComputeConfig(root={"gpu": ClusterConfig(cluster_name="gpu-cluster")})
+
+    def test_default_entry_requires_cluster_name(self):
+        with pytest.raises(ValueError, match="cluster_name"):
+            ComputeConfig(root={"__default__": ClusterConfig(instance_type="gpu-large")})
 
     def test_resolve_returns_default(self):
         cc = ComputeConfig(root={"__default__": ClusterConfig(cluster_name="cpu")})
@@ -90,6 +110,28 @@ class TestComputeConfig:
     def test_resolve_unknown_tag_returns_default(self):
         cc = ComputeConfig(root={"__default__": ClusterConfig(cluster_name="cpu")})
         assert cc.resolve("nonexistent").cluster_name == "cpu"
+
+    def test_resolve_instance_type_only_inherits_cluster_name(self):
+        cc = ComputeConfig(
+            root={
+                "__default__": ClusterConfig(cluster_name="k8s-compute"),
+                "gpu": ClusterConfig(instance_type="gpu-large"),
+            }
+        )
+        resolved = cc.resolve("gpu")
+        assert resolved.cluster_name == "k8s-compute"
+        assert resolved.instance_type == "gpu-large"
+
+    def test_resolve_cluster_name_only_inherits_instance_type(self):
+        cc = ComputeConfig(
+            root={
+                "__default__": ClusterConfig(cluster_name="k8s-compute", instance_type="cpu-small"),
+                "other": ClusterConfig(cluster_name="other-compute"),
+            }
+        )
+        resolved = cc.resolve("other")
+        assert resolved.cluster_name == "other-compute"
+        assert resolved.instance_type == "cpu-small"
 
 
 class TestExecutionConfig:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -188,6 +188,60 @@ class TestComputeResources:
                         for tag in node.tags
                     ), "compute settings don't match"
 
+    def test_instance_type_reaches_every_step_and_the_payload(
+        self, dummy_pipeline_compute_tag, dummy_plugin_config, multi_catalog
+    ):
+        """A configured instance type reaches each routed step's serialized payload.
+
+        Asserting a Python attribute alone would pass whether or not the SDK
+        recognises the field, so this asserts the value in the REST payload and
+        that validation reports no ``Unknown field`` warning for it.
+        """
+        dummy_plugin_config.compute.root["__default__"].instance_type = "cpu-small"
+        dummy_plugin_config.compute.root["compute-2"] = ClusterConfig(instance_type="gpu-large")
+        with patch.object(
+            AzureMLPipelineGenerator,
+            "get_kedro_pipeline",
+            return_value=dummy_pipeline_compute_tag,
+        ):
+            generator = AzureMLPipelineGenerator(
+                "dummy_pipeline_compute_tag",
+                "unit_test_env",
+                dummy_plugin_config,
+                {},
+                catalog=multi_catalog,
+                aml_env="unit_test/aml_env@latest",
+            )
+            az_pipeline = generator.generate()
+
+            az_pipeline.settings.default_compute = "cpu"
+            validation = az_pipeline._validate()
+            warnings = [str(w) for w in (validation._warnings or [])]
+            assert not any("instance_type" in w for w in warnings), warnings
+
+            payload = az_pipeline._to_rest_object().as_dict()
+            jobs = payload["properties"]["jobs"]
+            assert jobs["node1"]["resources"]["instance_type"] == "gpu-large", jobs["node1"]
+            for name in ("node2", "node3"):
+                assert jobs[name]["resources"]["instance_type"] == "cpu-small", jobs[name]
+
+    def test_no_instance_type_by_default(self, dummy_plugin_config, dummy_pipeline, multi_catalog):
+        """Without instance_type, no step payload carries one (current-behavior guard)."""
+        with patch.object(AzureMLPipelineGenerator, "get_kedro_pipeline", return_value=dummy_pipeline):
+            generator = AzureMLPipelineGenerator(
+                "test_no_instance_type",
+                "local",
+                dummy_plugin_config,
+                {},
+                catalog=multi_catalog,
+                aml_env="test@latest",
+            )
+            az_pipeline = generator.generate()
+
+            payload = az_pipeline._to_rest_object().as_dict()
+            for job_node in payload["properties"]["jobs"].values():
+                assert "instance_type" not in (job_node.get("resources") or {}), job_node
+
     def test_multiple_compute_tags_raises(self, dummy_plugin_config, dummy_pipeline, multi_catalog):
         """A node with more than one compute tag causes a ConfigException."""
         pipeline_name = "unit_test_pipeline"


### PR DESCRIPTION
## Description

Adds an optional `instance_type` field to compute entries (`ClusterConfig`) and passes it through to the Azure ML `command()` step, so nodes routed to an attached Kubernetes compute target (AKS or Azure Arc) can select the `InstanceType` custom resource they run under.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

On Kubernetes compute, Azure ML runs every step without an instance type under `defaultinstancetype`, whose stock definition limits a step to 2 CPU cores, 2 GiB of memory, and no GPU. The plugin never passed `instance_type`, so Kubernetes workloads were silently capped at that ceiling and GPU workloads were impossible.

Details:
- Tag entries merge field-wise over `__default__`: an entry may override `instance_type` alone (inheriting the cluster), `cluster_name` alone (inheriting the instance type), or both. `cluster_name` is therefore optional on non-default entries and a validator still requires it on `__default__`.
- `None` reproduces current behavior exactly, and AmlCompute clusters ignore the field, so no configuration migration is needed.
- Tests assert against the serialized pipeline payload and SDK validation warnings, not attribute round-trips.
- The configuration reference documents the `defaultinstancetype` ceiling, the AmlCompute no-op, and the merge rule.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Full suite: 435 passed at 100% coverage. Docs built strict with no issues; the new field renders in the configuration reference and the generated `ClusterConfig` API page.